### PR TITLE
first go at better multi editing support

### DIFF
--- a/action/entry.php
+++ b/action/entry.php
@@ -85,7 +85,11 @@ class action_plugin_struct_entry extends DokuWiki_Action_Plugin {
             $type = $col->getType();
             $label = $type->getLabel();
             $name = "Schema[$tablename][$label]";
-            $input = $type->valueEditor($name, $schemadata[$label]);
+            if($type->isMulti()) {
+                $input = $type->multiValueEditor($name, $schemadata[$label]);
+            } else {
+                $input = $type->valueEditor($name, $schemadata[$label]);
+            }
             $element = "<label>$label $input</label><br />";
             $html .= $element;
         }

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -103,6 +103,41 @@ abstract class AbstractBaseType {
     }
 
     /**
+     * Split a single value into multiple values
+     *
+     * This function is called on saving data when only a single value instead of an array
+     * was submitted.
+     *
+     * Types implementing their own @see multiValueEditor() will probably want to override this
+     *
+     * @param string $value
+     * @return array
+     */
+    public function splitValues($value) {
+        return array_map('trim', explode(',', $value));
+    }
+
+    /**
+     * Return the editor to edit multiple values
+     *
+     * Types can override this to provide a better alternative than multiple entry fields
+     *
+     * @param string $name the form base name where this has to be stored
+     * @param string[] $values the current values
+     * @return string html
+     */
+    public function multiValueEditor($name, $values) {
+        $html = '';
+        foreach($values as $value) {
+            $html .= $this->valueEditor($name.'[]', $value);
+        }
+        // empty field to add
+        $html .= $this->valueEditor($name.'[]', '');
+
+        return $html;
+    }
+
+    /**
      * Return the editor to edit a single value
      *
      * @param string $name the form name where this has to be stored

--- a/types/Text.php
+++ b/types/Text.php
@@ -24,6 +24,16 @@ class Text extends AbstractBaseType {
     }
 
     /**
+     * @param string $name
+     * @param \string[] $values
+     * @return string
+     */
+    public function multiValueEditor($name, $values) {
+        $value = join(', ',$values);
+        return $this->valueEditor($name, $value);
+    }
+
+    /**
      * Return the editor to edit a single value
      *
      * @param string $name the form name where this has to be stored
@@ -31,9 +41,7 @@ class Text extends AbstractBaseType {
      * @return string html
      */
     public function valueEditor($name, $value) {
-        if(is_array($value)) {$value = join(', ',$value);}
-        $html = '';
-        $html .= "<input name=\"$name\" value=\"$value\" />";
+        $html = "<input name=\"$name\" value=\"$value\" />";
         return "$html";
     }
 }


### PR DESCRIPTION
This is an idea how to implement multiedit support. The default is to simply repeat the single edit field for each existing value + 1 empty. The field name is made an array then.

Types can override this default behavior and implement their own editor. If they don't post an array, the spitValues() method will be called before saving.