### PR TITLE
Replace magic number with something obvious

### DIFF
--- a/action/autoloader.php
+++ b/action/autoloader.php
@@ -31,7 +31,7 @@ class action_plugin_struct_autoloader extends DokuWiki_Action_Plugin {
         $name = str_replace('\\', '/', $name);
         $name = str_replace('/test/', '/_test/', $name); // no underscore in test namespace
 
-        if(substr($name, 0, 14) == 'plugin/struct/') {
+        if(substr($name, 0, strlen('plugin/struct/')) == 'plugin/struct/') {
             $file = DOKU_PLUGIN . substr($name, 7) . '.php';
             if(file_exists($file)) {
                 require $file;


### PR DESCRIPTION
If the prefix 'plugin/struct/' is changed, it should be obvious what else has to be changed. That is not the case if the length-parameter for the substring is magic 14.