### PR TITLE
Fix sorting by a multi column

### DIFF
--- a/_test/Search.test.php
+++ b/_test/Search.test.php
@@ -132,6 +132,15 @@ class Search_struct_test extends StructTest {
         $this->assertEquals(1, count($result), 'result rows');
         $this->assertEquals(6, count($result[0]), 'result columns');
 
+        // sort by multi-column
+        $search->addSort('second');
+        $this->assertEquals(2, count($search->sortby));
+        $result = $search->execute();
+        $count = $search->getCount();
+        $this->assertEquals(1, $count, 'result count');
+        $this->assertEquals(1, count($result), 'result rows');
+        $this->assertEquals(6, count($result[0]), 'result columns');
+
         /*
         {#debugging
             list($sql, $opts) = $search->getSQL();

--- a/meta/Column.php
+++ b/meta/Column.php
@@ -104,10 +104,11 @@ class Column {
     /**
      * Returns the full column name. When table is set, prefixed by the table name
      *
+     * @param bool $forceSingleColumn Throw an exception if $this is a multi column
      * @return string
      */
-    public function getColName() {
-        if($this->isMulti()) throw new StructException('Calling getColName on a multi value column makes no sense.');
+    public function getColName($forceSingleColumn = true) {
+        if($forceSingleColumn && $this->isMulti()) throw new StructException('Calling getColName on a multi value column makes no sense.');
 
         $col = 'col'.$this->colref;
         if($this->table) $col = 'data_'.$this->table.'.'.$col;

--- a/meta/PageColumn.php
+++ b/meta/PageColumn.php
@@ -30,9 +30,10 @@ class PageColumn extends Column {
     }
 
     /**
+     * @param bool $forceSingleColumn ignored
      * @return string
      */
-    public function getColName() {
+    public function getColName($forceSingleColumn = true) {
         $col = 'pid';
         if($this->table) $col = 'data_'.$this->table.'.'.$col;
         return $col;

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -300,7 +300,7 @@ class Search {
         foreach($this->sortby as $sort) {
             list($col, $asc) = $sort;
             /** @var $col Column */
-            $order .= $col->getColName() . ' ';
+            $order .= $col->getColName(false) . ' ';
             $order .= ($asc) ? 'ASC' : 'DESC';
             $order .= ', ';
         }


### PR DESCRIPTION
A multicolumn is always sorted by its first value which is already copied
to the respective column in the table.