### PR TITLE
Ensure that struct output is only rendered once

### DIFF
--- a/action/output.php
+++ b/action/output.php
@@ -59,9 +59,6 @@ class action_plugin_struct_output extends DokuWiki_Action_Plugin {
         $this->lastread = '';
         if(!page_exists($ID)) return;
 
-        // we really only want to work on the main ID, not for any included page
-        if($ID != getID()) return;
-
         $ins = -1;
         $pos = 0;
         foreach($event->data->calls as $num => $call) {

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -13,6 +13,9 @@ use dokuwiki\plugin\struct\meta\SchemaData;
 if(!defined('DOKU_INC')) die();
 
 class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
+
+    protected $hasBeenRendered = false;
+
     /**
      * @return string Syntax mode type
      */
@@ -79,6 +82,10 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         global $REV;
         if($ID != $INFO['id']) return true;
         if(!$INFO['exists']) return true;
+        if($this->hasBeenRendered) return true;
+
+        // do not render the output twice on the same page, e.g. when another page has been included
+        $this->hasBeenRendered = true;
 
         $assignments = new Assignments();
         $tables = $assignments->getPageAssignments($ID);


### PR DESCRIPTION
If a page is included via the [include plugin](https://www.dokuwiki.org/plugin:include) then this bug may take two forms, depending on if the including page or the included page is rendered after the other one:

- If the including page is parsed together with the included page, then there will be no instructions for struct output stored on the included page. This means that the including page is displayed correctly, but the included page is missing the struct output
- If the included page is parsed separately from the including page, then it will have its struct output displayed correctly, however the including page will display its struct output once at its the beginning and once at the beginning of the included page

This PR adds the instructions always to the included pages, but checks during that parsing of that call, that its only called once per page.


SPR-491