### PR TITLE
Fix: Show single value in multi until overwritten

### DIFF
--- a/_test/SchemaDataSQL.test.php
+++ b/_test/SchemaDataSQL.test.php
@@ -43,7 +43,7 @@ class schemaDataSQL_struct_test extends StructTest {
                     'singles' => array(1,2),
                     'multis' => array(3),
                 ),
-                "SELECT col1,col2, GROUP_CONCAT(M3.value,'".Search::CONCAT_SEPARATOR."') AS col3
+                "SELECT col1,col2, ifnull(GROUP_CONCAT(M3.value,'".Search::CONCAT_SEPARATOR."'), DATA.col3) AS col3
                    FROM data_testtable DATA
                    LEFT OUTER JOIN multi_testtable M3
                      ON DATA.pid = M3.pid
@@ -61,8 +61,8 @@ class schemaDataSQL_struct_test extends StructTest {
                     'singles' => array(),
                     'multis' => array(1,2)
                 ),
-                "SELECT GROUP_CONCAT(M1.value,'".Search::CONCAT_SEPARATOR."') AS col1,
-                        GROUP_CONCAT(M2.value,'".Search::CONCAT_SEPARATOR."') AS col2
+                "SELECT ifnull(GROUP_CONCAT(M1.value,'".Search::CONCAT_SEPARATOR."'), DATA.col1) AS col1,
+                        ifnull(GROUP_CONCAT(M2.value,'".Search::CONCAT_SEPARATOR."'), DATA.col2) AS col2
                    FROM data_testtable DATA
                    LEFT OUTER JOIN multi_testtable M1
                      ON DATA.pid = M1.pid

--- a/_test/SchemaDataSQL.test.php
+++ b/_test/SchemaDataSQL.test.php
@@ -43,7 +43,7 @@ class schemaDataSQL_struct_test extends StructTest {
                     'singles' => array(1,2),
                     'multis' => array(3),
                 ),
-                "SELECT col1,col2, ifnull(GROUP_CONCAT(M3.value,'".Search::CONCAT_SEPARATOR."'), DATA.col3) AS col3
+                "SELECT col1,col2, IFNULL(GROUP_CONCAT(M3.value,'".Search::CONCAT_SEPARATOR."'), DATA.col3) AS col3
                    FROM data_testtable DATA
                    LEFT OUTER JOIN multi_testtable M3
                      ON DATA.pid = M3.pid
@@ -61,8 +61,8 @@ class schemaDataSQL_struct_test extends StructTest {
                     'singles' => array(),
                     'multis' => array(1,2)
                 ),
-                "SELECT ifnull(GROUP_CONCAT(M1.value,'".Search::CONCAT_SEPARATOR."'), DATA.col1) AS col1,
-                        ifnull(GROUP_CONCAT(M2.value,'".Search::CONCAT_SEPARATOR."'), DATA.col2) AS col2
+                "SELECT IFNULL(GROUP_CONCAT(M1.value,'".Search::CONCAT_SEPARATOR."'), DATA.col1) AS col1,
+                        IFNULL(GROUP_CONCAT(M2.value,'".Search::CONCAT_SEPARATOR."'), DATA.col2) AS col2
                    FROM data_testtable DATA
                    LEFT OUTER JOIN multi_testtable M1
                      ON DATA.pid = M1.pid

--- a/meta/SchemaData.php
+++ b/meta/SchemaData.php
@@ -245,7 +245,7 @@ class SchemaData extends Schema {
         $join = '';
         foreach($multis as $col) {
             $tn = 'M' . $col;
-            $colsel .= ", ifnull(GROUP_CONCAT($tn.value, '$sep'), DATA.col$col) AS col$col";
+            $colsel .= ", IFNULL(GROUP_CONCAT($tn.value, '$sep'), DATA.col$col) AS col$col";
             $join .= "LEFT OUTER JOIN $mtable $tn";
             $join .= " ON DATA.pid = $tn.pid AND DATA.rev = $tn.rev";
             $join .= " AND $tn.colref = $col\n";

--- a/meta/SchemaData.php
+++ b/meta/SchemaData.php
@@ -245,7 +245,7 @@ class SchemaData extends Schema {
         $join = '';
         foreach($multis as $col) {
             $tn = 'M' . $col;
-            $colsel .= ", GROUP_CONCAT($tn.value, '$sep') AS col$col";
+            $colsel .= ", ifnull(GROUP_CONCAT($tn.value, '$sep'), DATA.col$col) AS col$col";
             $join .= "LEFT OUTER JOIN $mtable $tn";
             $join .= " ON DATA.pid = $tn.pid AND DATA.rev = $tn.rev";
             $join .= " AND $tn.colref = $col\n";

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -263,7 +263,7 @@ class Search {
 
             if($col->isMulti()) {
                 $tn = 'M' . $col->getColref();
-                $select .= "GROUP_CONCAT($tn.value, '$sep') AS $CN, ";
+                $select .= "IFNULL(GROUP_CONCAT($tn.value, '$sep'), data_{$col->getTable()}.col{$col->getColref()}) AS $CN, ";
                 $from .= "\nLEFT OUTER JOIN multi_{$col->getTable()} AS $tn";
                 $from .= " ON data_{$col->getTable()}.pid = $tn.pid AND data_{$col->getTable()}.rev = $tn.rev";
                 $from .= " AND $tn.colref = {$col->getColref()}\n";


### PR DESCRIPTION
If a field was changed from single to multi value, then the former single value appeared to be "lost". Now it is still shown.

This pull-request depends on cosmocode/sqlite#38

ToDo:
- [ ] finish cosmocode/sqlite#38
- [x] Add this functionality to ``Search::execute()`` as well