### PR TITLE
Add $TITLE$ placeholder for aggregations

### DIFF
--- a/_test/SearchConfig.test.php
+++ b/_test/SearchConfig.test.php
@@ -21,6 +21,9 @@ class SearchConfig_struct_test extends StructTest {
         $this->assertEquals('foo:bar:baz', $searchConfig->applyFilterVars('$ID$'));
         $this->assertEquals('baz', $searchConfig->applyFilterVars('$PAGE$'));
         $this->assertEquals('foo:bar', $searchConfig->applyFilterVars('$NS$'));
+        $this->assertEquals('foo:bar:baz', $searchConfig->applyFilterVars('$TITLE$'));
+        saveWikiText($ID,'=====The Title=====','');
+        $this->assertEquals('The Title', $searchConfig->applyFilterVars('$TITLE$'));
         $this->assertEquals(date('Y-m-d'), $searchConfig->applyFilterVars('$TODAY$'));
         $this->assertEquals('', $searchConfig->applyFilterVars('$USER$'));
         $_SERVER['REMOTE_USER'] = 'user';

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -113,6 +113,7 @@ class SearchConfig extends Search {
                 '$ID$',
                 '$NS$',
                 '$PAGE$',
+                '$TITLE$',
                 '$USER$',
                 '$TODAY$'
             ),
@@ -120,6 +121,7 @@ class SearchConfig extends Search {
                 $ID,
                 getNS($ID),
                 noNS($ID),
+                p_get_first_heading($ID) ? p_get_first_heading($ID) : $ID,
                 isset($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'] : '',
                 date('Y-m-d')
             ),


### PR DESCRIPTION
When adding the title option (see #8 and #126), the placeholders ``$ID$`` and ``$PAGE$`` effectively ceased to work for this column. In order to still have the placeholder-functionality, I added the ``$TITLE$ ``placeholder. This placeholder evaluates to ``p_get_first_heading($ID)`` if it exists and to ``$ID`` otherwise.