### PR TITLE
Clean values in multiValueEditor, not in valueEditor

### DIFF
--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -305,12 +305,15 @@ abstract class AbstractBaseType {
     /**
      * Return the editor to edit a single value
      *
-     * @param string $name the form name where this has to be stored
+     * @param string $name  the form name where this has to be stored
      * @param string $value the current value
+     * @param bool   $isRaw set to true if the value already contains the correct raw value. e.g. for multi fields
      * @return string html
      */
-    public function valueEditor($name, $value) {
-        $value = $this->rawValue($value);
+    public function valueEditor($name, $value, $isRaw = false) {
+        if (!$isRaw) {
+            $value = $this->rawValue($value);
+        }
         $class = 'struct_' . strtolower($this->getClass());
 
         // support the autocomplete configurations out of the box

--- a/types/AbstractMultiBaseType.php
+++ b/types/AbstractMultiBaseType.php
@@ -19,11 +19,11 @@ abstract class AbstractMultiBaseType extends AbstractBaseType {
      * @return string
      */
     public function multiValueEditor($name, $values) {
-        $value = join(', ', $values);
+        $value = join(', ', array_map(array($this, 'rawValue'), $values));
 
         return
             '<div class="multiwrap">' .
-            $this->valueEditor($name, $value) .
+            $this->valueEditor($name, $value, true) .
             '</div>' .
             '<small>' .
             $this->getLang('multi') .

--- a/types/Checkbox.php
+++ b/types/Checkbox.php
@@ -24,9 +24,10 @@ class Checkbox extends AbstractBaseType {
      *
      * @param string $name
      * @param string $value
+     * @param bool $isRaw ignored
      * @return string
      */
-    public function valueEditor($name, $value) {
+    public function valueEditor($name, $value, $isRaw = false) {
         $class = 'struct_' . strtolower($this->getClass());
 
         $name = hsc($name);

--- a/types/Date.php
+++ b/types/Date.php
@@ -35,9 +35,10 @@ class Date extends AbstractBaseType {
      *
      * @param string $name the form name where this has to be stored
      * @param string $value the current value
+     * @param bool $isRaw ignored
      * @return string html
      */
-    public function valueEditor($name, $value) {
+    public function valueEditor($name, $value, $isRaw = false) {
         $name = hsc($name);
         $value = hsc($value);
 

--- a/types/Dropdown.php
+++ b/types/Dropdown.php
@@ -25,9 +25,10 @@ class Dropdown extends AbstractBaseType {
      *
      * @param string $name
      * @param string $value
+     * @param bool $isRaw ignored
      * @return string
      */
-    public function valueEditor($name, $value) {
+    public function valueEditor($name, $value, $isRaw = false) {
         $class = 'struct_' . strtolower($this->getClass());
 
         $name = hsc($name);

--- a/types/Media.php
+++ b/types/Media.php
@@ -94,9 +94,11 @@ class Media extends AbstractBaseType {
      *
      * @param string $name the form name where this has to be stored
      * @param string $value the current value
+     * @param bool $isRaw ignored
+     *
      * @return string html
      */
-    public function valueEditor($name, $value) {
+    public function valueEditor($name, $value, $isRaw = false) {
         $name = hsc($name);
         $value = hsc($value);
 

--- a/types/Wiki.php
+++ b/types/Wiki.php
@@ -32,9 +32,10 @@ class Wiki extends AbstractBaseType {
      *
      * @param string $name
      * @param string $value
+     * @param bool $isRaw ignored
      * @return string
      */
-    public function valueEditor($name, $value) {
+    public function valueEditor($name, $value, $isRaw = false) {
         $class = 'struct_'.strtolower($this->getClass());
         $name = hsc($name);
         $value = formText($value);


### PR DESCRIPTION
Since rawValue expects a single value it may not be able to handle multiple concatinated values.

This caused an error for the pagetype in a multi value field with usetitles enabled.