### PR TITLE
Fix broken page fields with title-option

### DIFF
--- a/action/inline.php
+++ b/action/inline.php
@@ -181,6 +181,7 @@ class action_plugin_struct_inline extends DokuWiki_Action_Plugin {
             $this->schemadata = null;
             return false;
         }
+        $this->schemadata->optionRawValue(true);
 
         $this->column = $this->schemadata->findColumn($field);
         if(!$this->column || !$this->column->isVisibleInEditor()) {


### PR DESCRIPTION
helper_plugin_struct::saveData() expects raw values

I am not entirely sure, that this is the right place to fix this.

See #155 :beetle: 