### PR TITLE
Fix pages in multi-page-title-fields being lost during preview

### DIFF
--- a/types/Page.php
+++ b/types/Page.php
@@ -162,6 +162,10 @@ class Page extends AbstractMultiBaseType {
      */
     public function rawValue($value) {
         if($this->config['usetitles']) {
+            if (cleanID($value) == $value) {
+                // This is already a raw value
+                return $value;
+            }
             list($value) = json_decode($value);
         }
         return $value;


### PR DESCRIPTION
This may not be the perfect place to fix it, but every alternative would involve possibly invasive design changes.
For more details and problem description see issue #140.