### PR TITLE
Write last value to multi-table on col change single->multi

### DIFF
--- a/meta/SchemaBuilder.php
+++ b/meta/SchemaBuilder.php
@@ -202,24 +202,32 @@ class SchemaBuilder {
         return true;
     }
 
-    private function migrateSingleToMulti($table, $colref) {
+    /**
+     * Write the latest value from an entry in a data_ table to the corresponding multi_table
+     *
+     * @param string $table
+     * @param int    $colref
+     */
+    protected function migrateSingleToMulti($table, $colref) {
         $sqlSelect = "SELECT pid, rev, col$colref AS value FROM data_$table WHERE latest = 1";
         $res = $this->sqlite->query($sqlSelect);
         $valueSet = $this->sqlite->res2arr($res);
         $this->sqlite->res_close($res);
         $valueString = array();
+        $arguments = array();
         foreach ($valueSet as $values) {
             if (blank($values['value']) || trim($values['value']) == '') {
                 continue;
             }
-            $valueString[] = "($colref, '$values[pid]', $values[rev], 1, '$values[value]')";
+            $valueString[] = "(?, ?, ?, ?, ?)";
+            $arguments = array_merge($arguments, array($colref, $values['pid'], $values['rev'], 1, $values['value']));
         }
         if (empty($valueString)) {
             return;
         }
         $valueString = join(',', $valueString);
         $sqlInsert = "INSERT OR REPLACE INTO multi_$table (colref, pid, rev, row, value) VALUES $valueString";
-        $this->sqlite->query($sqlInsert);
+        $this->sqlite->query($sqlInsert, $arguments);
     }
 
     /**


### PR DESCRIPTION
The Problem we are trying solve is that the current value "disappears" when a column is made into a multi-column. The reason for this is that there is not yet a value for the current revision in the multi-table and we do not look into the data-table anymore for that column. Hence on change from single to multi we write the current value of that column for every page into the multi table.

Review welcome.

This is intended to replace and therefore closes #113.