### PR TITLE
Do not hide rows if table is only pid and/or rev

### DIFF
--- a/meta/Search.php
+++ b/meta/Search.php
@@ -280,6 +280,8 @@ class Search {
         $this->result_pids = array();
         $result = array();
         $cursor = -1;
+        $pageidAndRevOnly = !(count($this->columns) > 2 || $this->columns[0]->getTid() ||
+            !empty($this->columns[1]) && $this->columns[1]->getTid());
         while($row = $res->fetch(\PDO::FETCH_ASSOC)) {
             $cursor++;
             if($cursor < $this->range_begin) continue;
@@ -294,13 +296,13 @@ class Search {
                     $val = explode(self::CONCAT_SEPARATOR, $val);
                 }
                 $value = new Value($col, $val);
-                $isempty &= $this->isEmptyValue($value, $row['PID']);
+                $isempty &= $this->isEmptyValue($value);
                 $resrow[] = $value;
                 $C++;
             }
 
             // skip empty rows
-            if($isempty) {
+            if($isempty && !$pageidAndRevOnly) {
                 $cursor--;
                 continue;
             }
@@ -529,12 +531,11 @@ class Search {
      * Check if the given row is empty or references our own row
      *
      * @param Value $value
-     * @param string $pid
      * @return bool
      */
-    protected function isEmptyValue(Value $value, $pid) {
-        if($value->isEmpty()) return true;
-        if(is_a($value->getColumn()->getType(), Page::class) && $value->getRawValue() == $pid) return true;
+    protected function isEmptyValue(Value $value) {
+        if ($value->isEmpty()) return true;
+        if ($value->getColumn()->getTid() == 0) return true;
         return false;
     }
 }

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -280,8 +280,9 @@ class Search {
         $this->result_pids = array();
         $result = array();
         $cursor = -1;
-        $pageidAndRevOnly = !(count($this->columns) > 2 || $this->columns[0]->getTid() ||
-            !empty($this->columns[1]) && $this->columns[1]->getTid());
+        $pageidAndRevOnly = array_reduce($this->columns, function ($pageidAndRevOnly, Column $col) {
+            return $pageidAndRevOnly && ($col->getTid() == 0);
+        }, true);
         while($row = $res->fetch(\PDO::FETCH_ASSOC)) {
             $cursor++;
             if($cursor < $this->range_begin) continue;


### PR DESCRIPTION
This hides rows in aggregation-tables/results if they are empty except for the `%pageid%` or `%lastupdated%` column. However if a table consists solely of a `%pageid%` and/or a `%lastupdated%` column, then no rows will be skipped.

However the second part has the consequence that it is not possible to remove a page from such a table by deleting all its struct data for that schema. The only ways would be:
- To delete the page
- To unassign it

Review welcome.

This fixes #150 