### PR TITLE
Always use raw values for editors

### DIFF
--- a/action/entry.php
+++ b/action/entry.php
@@ -226,8 +226,8 @@ class action_plugin_struct_entry extends DokuWiki_Action_Plugin {
         foreach($schemadata as $field) {
             $label = $field->getColumn()->getLabel();
             if(isset($postdata[$label])) {
-                // posted data trumps stored data
-                $field->setValue($postdata[$label]);
+                // posted data trumps stored data -> set as raw value
+                $field->setValue($postdata[$label], true);
             }
             $html .=  $this->makeField($field, self::$VAR . "[$tablename][$label]");
         }

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -283,12 +283,12 @@ abstract class AbstractBaseType {
      * Types can override this to provide a better alternative than multiple entry fields
      *
      * @param string $name the form base name where this has to be stored
-     * @param string[] $values the current values
+     * @param string[] $rawvalues the current values
      * @return string html
      */
-    public function multiValueEditor($name, $values) {
+    public function multiValueEditor($name, $rawvalues) {
         $html = '';
-        foreach($values as $value) {
+        foreach($rawvalues as $value) {
             $html .= '<div class="multiwrap">';
             $html .= $this->valueEditor($name . '[]', $value);
             $html .= '</div>';
@@ -307,14 +307,10 @@ abstract class AbstractBaseType {
      * Return the editor to edit a single value
      *
      * @param string $name  the form name where this has to be stored
-     * @param string $value the current value
-     * @param bool   $isRaw set to true if the value already contains the correct raw value. e.g. for multi fields
+     * @param string $rawvalue the current value
      * @return string html
      */
-    public function valueEditor($name, $value, $isRaw = false) {
-        if (!$isRaw) {
-            $value = $this->rawValue($value);
-        }
+    public function valueEditor($name, $rawvalue) {
         $class = 'struct_' . strtolower($this->getClass());
 
         // support the autocomplete configurations out of the box
@@ -323,8 +319,8 @@ abstract class AbstractBaseType {
         }
 
         $name = hsc($name);
-        $value = hsc($value);
-        $html = "<input name=\"$name\" value=\"$value\" class=\"$class\" />";
+        $rawvalue = hsc($rawvalue);
+        $html = "<input name=\"$name\" value=\"$rawvalue\" class=\"$class\" />";
         return "$html";
     }
 

--- a/types/AbstractMultiBaseType.php
+++ b/types/AbstractMultiBaseType.php
@@ -15,11 +15,11 @@ abstract class AbstractMultiBaseType extends AbstractBaseType {
 
     /**
      * @param string $name
-     * @param \string[] $values
+     * @param \string[] $rawvalues
      * @return string
      */
-    public function multiValueEditor($name, $values) {
-        $value = join(', ', array_map(array($this, 'rawValue'), $values));
+    public function multiValueEditor($name, $rawvalues) {
+        $value = join(', ', array_map(array($this, 'rawValue'), $rawvalues));
 
         return
             '<div class="multiwrap">' .

--- a/types/Checkbox.php
+++ b/types/Checkbox.php
@@ -23,18 +23,17 @@ class Checkbox extends AbstractBaseType {
      * A single checkbox, additional values are ignored
      *
      * @param string $name
-     * @param string $value
-     * @param bool $isRaw ignored
+     * @param string $rawvalue
      * @return string
      */
-    public function valueEditor($name, $value, $isRaw = false) {
+    public function valueEditor($name, $rawvalue) {
         $class = 'struct_' . strtolower($this->getClass());
 
         $name = hsc($name);
         $options = $this->getOptions();
         $opt = array_shift($options);
 
-        if($value == $opt) {
+        if($rawvalue == $opt) {
             $checked = 'checked="checked"';
         } else {
             $checked = '';
@@ -48,16 +47,16 @@ class Checkbox extends AbstractBaseType {
      * Multiple checkboxes
      *
      * @param string $name
-     * @param \string[] $values
+     * @param \string[] $rawvalues
      * @return string
      */
-    public function multiValueEditor($name, $values) {
+    public function multiValueEditor($name, $rawvalues) {
         $class = 'struct_' . strtolower($this->getClass());
 
         $name = hsc($name);
         $html = '';
         foreach($this->getOptions() as $opt) {
-            if(in_array($opt, $values)) {
+            if(in_array($opt, $rawvalues)) {
                 $checked = 'checked="checked"';
             } else {
                 $checked = '';

--- a/types/Date.php
+++ b/types/Date.php
@@ -34,19 +34,18 @@ class Date extends AbstractBaseType {
      * Return the editor to edit a single value
      *
      * @param string $name the form name where this has to be stored
-     * @param string $value the current value
-     * @param bool $isRaw ignored
+     * @param string $rawvalue the current value
      * @return string html
      */
-    public function valueEditor($name, $value, $isRaw = false) {
+    public function valueEditor($name, $rawvalue) {
         $name = hsc($name);
-        $value = hsc($value);
+        $rawvalue = hsc($rawvalue);
 
-        if($this->config['prefilltoday'] && !$value) {
-            $value = date('Y-m-d');
+        if($this->config['prefilltoday'] && !$rawvalue) {
+            $rawvalue = date('Y-m-d');
         }
 
-        $html = "<input class=\"struct_date\" name=\"$name\" value=\"$value\" />";
+        $html = "<input class=\"struct_date\" name=\"$name\" value=\"$rawvalue\" />";
         return "$html";
     }
 

--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -32,15 +32,14 @@ class DateTime extends Date {
      * Return the editor to edit a single value
      *
      * @param string $name the form name where this has to be stored
-     * @param string $value the current value
-     * @param bool $isRaw ignored
+     * @param string $rawvalue the current value
      * @return string html
      */
-    public function valueEditor($name, $value, $isRaw = false) {
-        if($this->config['prefilltoday'] && !$value) {
-            $value = date('Y-m-d H:i:s');
+    public function valueEditor($name, $rawvalue) {
+        if($this->config['prefilltoday'] && !$rawvalue) {
+            $rawvalue = date('Y-m-d H:i:s');
         }
-        return parent::valueEditor($name, $value);
+        return parent::valueEditor($name, $rawvalue);
     }
 
     /**

--- a/types/Dropdown.php
+++ b/types/Dropdown.php
@@ -162,19 +162,16 @@ class Dropdown extends AbstractBaseType {
      * A Dropdown with a single value to pick
      *
      * @param string $name
-     * @param string $value
-     * @param bool $isRaw ignored
+     * @param string $rawvalue
      * @return string
      */
-    public function valueEditor($name, $value, $isRaw = false) {
+    public function valueEditor($name, $rawvalue) {
         $class = 'struct_' . strtolower($this->getClass());
-
-        if(!$isRaw) $value = $this->rawValue($value);
 
         $name = hsc($name);
         $html = "<select name=\"$name\" class=\"$class\">";
         foreach($this->getOptions() as $opt => $val) {
-            if($opt == $value) {
+            if($opt == $rawvalue) {
                 $selected = 'selected="selected"';
             } else {
                 $selected = '';
@@ -191,18 +188,16 @@ class Dropdown extends AbstractBaseType {
      * A dropdown that allows to pick multiple values
      *
      * @param string $name
-     * @param \string[] $values
+     * @param \string[] $rawvalues
      * @return string
      */
-    public function multiValueEditor($name, $values) {
+    public function multiValueEditor($name, $rawvalues) {
         $class = 'struct_' . strtolower($this->getClass());
-
-        $values = array_map(array($this, 'rawValue'), $values);
 
         $name = hsc($name);
         $html = "<select name=\"{$name}[]\" class=\"$class\" multiple=\"multiple\" size=\"5\">";
         foreach($this->getOptions() as $opt) {
-            if(in_array($opt, $values)) {
+            if(in_array($opt, $rawvalues)) {
                 $selected = 'selected="selected"';
             } else {
                 $selected = '';

--- a/types/Media.php
+++ b/types/Media.php
@@ -93,20 +93,19 @@ class Media extends AbstractBaseType {
      * Return the editor to edit a single value
      *
      * @param string $name the form name where this has to be stored
-     * @param string $value the current value
-     * @param bool $isRaw ignored
+     * @param string $rawvalue the current value
      *
      * @return string html
      */
-    public function valueEditor($name, $value, $isRaw = false) {
+    public function valueEditor($name, $rawvalue) {
         $name = hsc($name);
-        $value = hsc($value);
+        $rawvalue = hsc($rawvalue);
         static $count = 0;
         $count++;
 
         $id = 'struct__' . md5($name.$count);
 
-        $html = "<input id=\"$id\" class=\"struct_media\"  name=\"$name\" value=\"$value\" />";
+        $html = "<input id=\"$id\" class=\"struct_media\"  name=\"$name\" value=\"$rawvalue\" />";
         $html .= "<button type=\"button\" class=\"struct_media\">";
         $html .= "<img src=\"" . DOKU_BASE . "lib/images/toolbar/image.png\" height=\"16\" width=\"16\">";
         $html .= "</button>";

--- a/types/Wiki.php
+++ b/types/Wiki.php
@@ -31,16 +31,15 @@ class Wiki extends AbstractBaseType {
      * Use a text area for input
      *
      * @param string $name
-     * @param string $value
-     * @param bool $isRaw ignored
+     * @param string $rawvalue
      * @return string
      */
-    public function valueEditor($name, $value, $isRaw = false) {
+    public function valueEditor($name, $rawvalue) {
         $class = 'struct_'.strtolower($this->getClass());
         $name = hsc($name);
-        $value = formText($value);
+        $rawvalue = formText($rawvalue);
 
-        $html = "<textarea name=\"$name\" class=\"$class\">$value</textarea>";
+        $html = "<textarea name=\"$name\" class=\"$class\">$rawvalue</textarea>";
         return "$html";
     }
 


### PR DESCRIPTION
This is another attempt to fix #140. The valueEditor() and multiValueEditor() now always expect raw values to be passed. The Value class was adjusted accordingly. It now allows to set the raw value
(which is what we get from POST). If done, the Value object is treated as a rawonly Value that will throw an exception when you try to access value or displayvalue.

replaces #159 