### PR TITLE
Show new row and reset form in Lookup Editor

### DIFF
--- a/action/lookup.php
+++ b/action/lookup.php
@@ -150,6 +150,7 @@ class action_plugin_struct_lookup extends DokuWiki_Action_Plugin {
 
         echo '<button type="submit">' . $lang['btn_save'] . '</button>';
 
+        echo '<div class="err"></div>';
         echo '</fieldset>';
         echo '</div>';
 

--- a/action/lookup.php
+++ b/action/lookup.php
@@ -10,7 +10,9 @@
 use dokuwiki\plugin\struct\meta\AccessTable;
 use dokuwiki\plugin\struct\meta\AccessTableData;
 use dokuwiki\plugin\struct\meta\Column;
+use dokuwiki\plugin\struct\meta\LookupTable;
 use dokuwiki\plugin\struct\meta\Schema;
+use dokuwiki\plugin\struct\meta\SearchConfig;
 use dokuwiki\plugin\struct\meta\StructException;
 use dokuwiki\plugin\struct\meta\Value;
 
@@ -107,6 +109,19 @@ class action_plugin_struct_lookup extends DokuWiki_Action_Plugin {
             throw new StructException("Validation failed:\n%s", join("\n", $validator->getErrors()));
         }
         $validator->saveData();
+
+        // create a new row based on the original aggregation config for the new pid
+        $pid = $access->getPid();
+        $config = json_decode($INPUT->str('searchconf'), true);
+        $config['filter'] = array(array('%rowid%', '=', $pid, 'AND'));
+        $lookup = new LookupTable(
+            '', // current page doesn't matter
+            'xhtml',
+            new Doku_Renderer_xhtml(),
+            new SearchConfig($config)
+        );
+
+        echo $lookup->getFirstRow();
     }
 
     /**

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -20,6 +20,7 @@ $lang['schemaname'] = 'Schema Name:';
 $lang['save'] = 'Save';
 $lang['createhint'] = 'Please note: schemas can not be renamed later';
 $lang['pagelabel'] = 'Page';
+$lang['rowlabel'] = 'Row #';
 $lang['revisionlabel'] = 'Last Updated';
 $lang['summary'] = 'Struct data changed';
 $lang['export'] = 'Export Schema as JSON';

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -81,6 +81,15 @@ abstract class AccessTable {
     }
 
     /**
+     * The current pid
+     *
+     * @return int|string
+     */
+    public function getPid() {
+        return $this->pid;
+    }
+
+    /**
      * Should remove the current data, by either deleting or ovewriting it
      *
      * @return bool if the delete succeeded

--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -329,39 +329,49 @@ class AggregationTable {
     protected function renderResult() {
         $this->renderer->tabletbody_open();
         foreach($this->result as $rownum => $row) {
-            $this->renderer->tablerow_open();
-
-            // add data attribute for inline edit
-            if($this->mode == 'xhtml') {
-                $pid = $this->resultPIDs[$rownum];
-                $this->renderer->doc = substr(rtrim($this->renderer->doc), 0, -1); // remove closing '>'
-                $this->renderer->doc .= ' data-pid="' . hsc($pid) . '">';
-            }
-
-            // row number column
-            if($this->data['rownumbers']) {
-                $this->renderer->tablecell_open();
-                $this->renderer->doc .= $rownum + 1;
-                $this->renderer->tablecell_close();
-            }
-
-            /** @var Value $value */
-            foreach($row as $colnum => $value) {
-                $this->renderer->tablecell_open();
-                $value->render($this->renderer, $this->mode);
-                $this->renderer->tablecell_close();
-
-                // summarize
-                if($this->data['summarize'] && is_numeric($value->getValue())) {
-                    if(!isset($this->sums[$colnum])) {
-                        $this->sums[$colnum] = 0;
-                    }
-                    $this->sums[$colnum] += $value->getValue();
-                }
-            }
-            $this->renderer->tablerow_close();
+            $this->renderResultRow($rownum, $row);
         }
         $this->renderer->tabletbody_close();
+    }
+
+    /**
+     * Render a single result row
+     *
+     * @param int $rownum
+     * @param array $row
+     */
+    protected function renderResultRow($rownum, $row) {
+        $this->renderer->tablerow_open();
+
+        // add data attribute for inline edit
+        if($this->mode == 'xhtml') {
+            $pid = $this->resultPIDs[$rownum];
+            $this->renderer->doc = substr(rtrim($this->renderer->doc), 0, -1); // remove closing '>'
+            $this->renderer->doc .= ' data-pid="' . hsc($pid) . '">';
+        }
+
+        // row number column
+        if($this->data['rownumbers']) {
+            $this->renderer->tablecell_open();
+            $this->renderer->doc .= $rownum + 1;
+            $this->renderer->tablecell_close();
+        }
+
+        /** @var Value $value */
+        foreach($row as $colnum => $value) {
+            $this->renderer->tablecell_open();
+            $value->render($this->renderer, $this->mode);
+            $this->renderer->tablecell_close();
+
+            // summarize
+            if($this->data['summarize'] && is_numeric($value->getValue())) {
+                if(!isset($this->sums[$colnum])) {
+                    $this->sums[$colnum] = 0;
+                }
+                $this->sums[$colnum] += $value->getValue();
+            }
+        }
+        $this->renderer->tablerow_close();
     }
 
     /**

--- a/meta/LookupTable.php
+++ b/meta/LookupTable.php
@@ -28,8 +28,12 @@ class LookupTable extends AggregationTable {
 
         $table = $this->columns[0]->getTable();
 
+        $config = $this->searchConfig->getConf();
+        if(isset($config['filter'])) unset($config['filter']);
+        $config = hsc(json_encode($config));
+
         // wrapping div
-        $this->renderer->doc .= "<div class=\"structaggregation structlookup\" data-schema=\"$table\">";
+        $this->renderer->doc .= "<div class=\"structaggregation structlookup\" data-schema=\"$table\" data-searchconf=\"$config\">";
 
         // unique identifier for this aggregation
         $this->renderer->info['struct_table_hash'] = md5(var_export($this->data, true));
@@ -41,4 +45,15 @@ class LookupTable extends AggregationTable {
     protected function renderEmptyResult() {
     }
 
+    /**
+     * Renders the first result row and returns it
+     *
+     * Only used for rendering new rows via JS (where the first row is the only one)
+     *
+     * @return string
+     */
+    public function getFirstRow() {
+        $this->renderResultRow(0, $this->result[0]);
+        return $this->renderer->doc;
+    }
 }

--- a/meta/RowColumn.php
+++ b/meta/RowColumn.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+use dokuwiki\plugin\struct\types\Decimal;
+
+/**
+ * Like a Page Column but for Lookups using a decimal type
+ */
+class RowColumn extends PageColumn {
+
+    /** @noinspection PhpMissingParentConstructorInspection
+     * @param int $sort
+     * @param Decimal $type
+     * @param string $table
+     */
+    public function __construct($sort, Decimal $type, $table) {
+        if($type->isMulti()) throw new StructException('RowColumns can not be multi value types!');
+        Column::__construct($sort, $type, 0, true, $table);
+    }
+
+    /**
+     * @return string always '%rowid%'
+     */
+    public function getLabel() {
+        return '%rowid%';
+    }
+
+    /**
+     * @return string preconfigured label
+     */
+    public function getTranslatedLabel() {
+        /** @var \helper_plugin_struct_config $helper */
+        $helper = plugin_load('helper', 'struct_config');
+        return $helper->getLang('rowlabel');
+    }
+}

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -3,6 +3,7 @@
 namespace dokuwiki\plugin\struct\meta;
 
 use dokuwiki\plugin\struct\types\DateTime;
+use dokuwiki\plugin\struct\types\Decimal;
 use dokuwiki\plugin\struct\types\Page;
 
 class Search {
@@ -488,10 +489,10 @@ class Search {
      */
     public function findColumn($colname) {
         if(!$this->schemas) throw new StructException('noschemas');
+        $schema_list = array_keys($this->schemas);
 
-        // add "fake" column for special col (unless it's a lookup)
+        // add "fake" column for special col
         if(!(reset($this->schemas)->isLookup())) {
-            $schema_list = array_keys($this->schemas);
             if($colname == '%pageid%') {
                 return new PageColumn(0, new Page(), $schema_list[0]);
             }
@@ -500,6 +501,10 @@ class Search {
             }
             if($colname == '%lastupdate%') {
                 return new RevisionColumn(0, new DateTime(), $schema_list[0]);
+            }
+        } else {
+            if($colname == '%rowid%') {
+                return new RowColumn(0, new Decimal(), $schema_list[0]);
             }
         }
 

--- a/script/InlineEditor.js
+++ b/script/InlineEditor.js
@@ -4,7 +4,7 @@
 var InlineEditor = function ($table) {
 
 
-    $table.find('td').dblclick(function (e) {
+    $table.on('dblclick', 'td', function (e) {
         e.preventDefault();
 
         var $self = jQuery(this);

--- a/script/LookupEditor.js
+++ b/script/LookupEditor.js
@@ -15,6 +15,11 @@ var LookupEditor = function ($table) {
         $table.find('tr').each(function () {
             var $me = jQuery(this);
 
+            // already added here?
+            if ($me.find('th.action, td.action').length) {
+                return;
+            }
+
             // empty header cells
             if ($me.parent().is('thead')) {
                 $me.append('<th class="action"></th>');
@@ -22,7 +27,7 @@ var LookupEditor = function ($table) {
             }
 
             // delete buttons for rows
-            var $td = jQuery('<td></td>');
+            var $td = jQuery('<td class="action"></td>');
             var pid = $me.data('pid');
             if (pid === '') return;
 
@@ -63,10 +68,16 @@ var LookupEditor = function ($table) {
      */
     function addForm(data) {
         if ($form) $form.remove();
+        var $agg = $table.parents('.structaggregation');
+
         $form = jQuery('<form></form>');
         $form.html(data);
-        $table.parents('.structaggregation').append($form);
-
+        jQuery('<input>').attr({
+            type: 'hidden',
+            name: 'searchconf',
+            value: $agg.attr('data-searchconf')
+        }).appendTo($form); // add the search config to the form
+        $agg.append($form);
         EntryEditor($form);
 
         $form.submit(function (e) {
@@ -76,8 +87,9 @@ var LookupEditor = function ($table) {
                 DOKU_BASE + 'lib/exe/ajax.php',
                 $form.serialize()
             )
-                .done(function () {
-                    // FIXME
+                .done(function (data) {
+                    $table.find('tbody').append(data);
+                    addDeleteRowButtons(); // add the delete button to the new row
                 })
                 .fail(function (xhr) {
                     // FIXME

--- a/script/LookupEditor.js
+++ b/script/LookupEditor.js
@@ -4,6 +4,7 @@
 var LookupEditor = function ($table) {
 
     var $form = null;
+    var formdata;
 
     var schema = $table.parents('.structaggregation').data('schema');
     if (!schema) return;
@@ -80,8 +81,11 @@ var LookupEditor = function ($table) {
         $agg.append($form);
         EntryEditor($form);
 
+        var $errors = $form.find('div.err').hide();
+
         $form.submit(function (e) {
             e.preventDefault();
+            $errors.hide();
 
             jQuery.post(
                 DOKU_BASE + 'lib/exe/ajax.php',
@@ -90,10 +94,10 @@ var LookupEditor = function ($table) {
                 .done(function (data) {
                     $table.find('tbody').append(data);
                     addDeleteRowButtons(); // add the delete button to the new row
+                    addForm(formdata); // reset the whole form
                 })
                 .fail(function (xhr) {
-                    // FIXME
-                    alert(xhr.responseText)
+                    $errors.text(xhr.responseText).show();
                 })
         });
     }
@@ -113,6 +117,7 @@ var LookupEditor = function ($table) {
         },
         function (data) {
             if (!data) return;
+            formdata = data;
             addDeleteRowButtons();
             addForm(data);
         }

--- a/style.less
+++ b/style.less
@@ -260,7 +260,9 @@ form.struct_newschema {
     }
 
 }
-
+/**
+ * Lookup Aggregation Editor
+ */
 .dokuwiki .structlookup {
     table.inline {
         min-width: 100%;
@@ -271,6 +273,9 @@ form.struct_newschema {
     }
 }
 
+/**
+ * Inline Editor Overlay
+ */
 .dokuwiki .struct_inlineditor {
     position: absolute;
     top: 0;
@@ -288,11 +293,19 @@ form.struct_newschema {
         margin-top: 5px;
     }
 
+}
+
+/**
+ * Errors on AJAX
+ */
+.dokuwiki .structlookup form,
+.dokuwiki .struct_inlineditor {
     .err {
         font-size: 90%;
         margin-top: 5px;
         padding: 5px;
         background-color: @ini_highlight;
         color: @ini_text;
+        text-align: left;
     }
 }

--- a/syntax/lookup.php
+++ b/syntax/lookup.php
@@ -41,6 +41,8 @@ class syntax_plugin_struct_lookup extends syntax_plugin_struct_table {
 
         // adjust some things for the lookup editor
         $config['cols'] = array('*'); // always select all columns
+        if(isset($config['summarize'])) unset($config['summarize']); // this is hard to update dynamically
+        if(isset($config['rownumbers'])) unset($config['rownumbers']); // this annoying to update dynamically
 
         return $config;
     }


### PR DESCRIPTION
This is based on top of #165. This adds the last missing features to the lookup editor. When a new row is added, that row is now rendered and dynamically added to the end of the table and the from is reset to the initial state.