### PR TITLE
Show multi multi fields of types where raw- and display-value differ correctly

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -94,7 +94,7 @@ class action_plugin_struct_edit extends DokuWiki_Action_Plugin {
             $label = $field->getColumn()->getLabel();
             if(isset($postdata[$label])) {
                 // posted data trumps stored data
-                $field->setValue($postdata[$label]);
+                $field->setValue($postdata[$label], true);
             }
             $html .= $this->makeField($field, self::$VAR . "[$tablename][$label]");
         }

--- a/types/AbstractMultiBaseType.php
+++ b/types/AbstractMultiBaseType.php
@@ -19,11 +19,11 @@ abstract class AbstractMultiBaseType extends AbstractBaseType {
      * @return string
      */
     public function multiValueEditor($name, $rawvalues) {
-        $value = join(', ', array_map(array($this, 'rawValue'), $rawvalues));
+        $value = join(', ', $rawvalues);
 
         return
             '<div class="multiwrap">' .
-            $this->valueEditor($name, $value, true) .
+            $this->valueEditor($name, $value) .
             '</div>' .
             '<small>' .
             $this->getLang('multi') .


### PR DESCRIPTION
There were some overlooked raw-value calls/missing flags. This should now hopefully be finally fixed.