### PR TITLE
Fix datetime entry

### DIFF
--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -36,10 +36,15 @@ class DateTime extends Date {
      * @return string html
      */
     public function valueEditor($name, $rawvalue) {
+        $name = hsc($name);
+        $rawvalue = hsc($rawvalue);
+
         if($this->config['prefilltoday'] && !$rawvalue) {
             $rawvalue = date('Y-m-d H:i:s');
         }
-        return parent::valueEditor($name, $rawvalue);
+
+        $html = "<input class=\"struct_datetime\" name=\"$name\" value=\"$rawvalue\" />";
+        return "$html";
     }
 
     /**


### PR DESCRIPTION
With this the correct class will be set in all the scenarios (page-edit,
inline, lookup). Then changing the date via the datepicker will always
generate time-template as defined in script/EntryEditor.js

However there are still two other points to fix/discuss:
- [ ] this fix currently duplicates code from `types/Date.php`. We could use their `valueEditor()` and then adjust the returned html, but that may not be less complex either.
- [ ] The javascript that generates that "time-template" does not respect the settings made in the schema-editor for that field: [L34](https://github.com/cosmocode/dokuwiki-plugin-struct/blob/1707798d179f1fd7546216573b23820f8390a31f/script/EntryEditor.js#L34)

Fixes #204