### PR TITLE
Create assignments and save titles for pages created with bureaucracy

### DIFF
--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -104,6 +104,12 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin {
             $validator = $access->getValidator($data);
             if($validator->validate()) {
                 $validator->saveData($time);
+
+                // make sure this schema is assigned
+                $assignments->assignPageSchema(
+                    $id,
+                    $validator->getAccessTable()->getSchema()->getTable()
+                );
             }
         }
 

--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -110,6 +110,9 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin {
                     $id,
                     $validator->getAccessTable()->getSchema()->getTable()
                 );
+
+                // trigger meta data rendering to set page title
+                p_get_metadata($id);
             }
         }
 


### PR DESCRIPTION
This fixes #202 by creating a new assignment for new tables.
It also triggers an immediate rendering of the metadata of the new page, so that its title is correctly displayed on an aggregation of the respective schema on the thank-you page.