### PR TITLE
Fix: Do not render dynamic filters on pdf export

### DIFF
--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -280,7 +280,10 @@ class AggregationTable {
     protected function renderDynamicFilters() {
         if($this->mode != 'xhtml') return;
         if(!$this->data['dynfilters']) return;
-        global $conf;
+        global $conf, $ACT;
+        if ($ACT == 'export_pdf') {
+            return;
+        }
 
         $this->renderer->doc .= '<tr class="dataflt">';
 

--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -280,10 +280,10 @@ class AggregationTable {
     protected function renderDynamicFilters() {
         if($this->mode != 'xhtml') return;
         if(!$this->data['dynfilters']) return;
-        global $conf, $ACT;
-        if ($ACT == 'export_pdf') {
+        if (is_a($this->renderer, 'renderer_plugin_dw2pdf')) {
             return;
         }
+        global $conf;
 
         $this->renderer->doc .= '<tr class="dataflt">';
 


### PR DESCRIPTION
Do not render the dynamic filters, because mpdf 6, which creates the pdf, is unable to parse `display: none` neither on the `tr` nor on the `th` or `td` tags and hence removing those filters with CSS doesn't work.
This might improve with mpdf 7.

This fixes #169 and fixes SPR-689