### PR TITLE
Enable usage in sidebars etc.

### DIFF
--- a/_test/AccessTableDataReplacement.test.php
+++ b/_test/AccessTableDataReplacement.test.php
@@ -69,8 +69,8 @@ class AccessTableDataReplacement_struct_test extends StructTest {
     }
 
     public function test_simple() {
-        global $ID;
-        $ID = 'start';
+        global $INFO;
+        $INFO['id'] = 'start';
         $lines = array(
             "schema    : bar",
             "cols      : %pageid%, data",

--- a/_test/SearchConfig.test.php
+++ b/_test/SearchConfig.test.php
@@ -13,8 +13,8 @@ use dokuwiki\plugin\struct\test\mock\SearchConfig;
 class SearchConfig_struct_test extends StructTest {
 
     public function test_filtervars_simple() {
-        global $ID;
-        $ID = 'foo:bar:baz';
+        global $INFO;
+        $INFO['id'] = 'foo:bar:baz';
 
         $searchConfig = new SearchConfig(array());
 
@@ -32,13 +32,13 @@ class SearchConfig_struct_test extends StructTest {
     }
 
     public function test_filtervars_struct() {
-        global $ID;
-        $ID = 'foo:bar:baz';
+        global $INFO;
+        $INFO['id'] = 'foo:bar:baz';
 
         // prepare some struct data
         $sb = new meta\SchemaImporter('schema1', file_get_contents(__DIR__ . '/json/schema1.struct.json'));
         $sb->build();
-        $schemaData = meta\AccessTable::byTableName('schema1', $ID, time());
+        $schemaData = meta\AccessTable::byTableName('schema1', $INFO['id'], time());
         $schemaData->saveData(
             array(
                 'first' => 'test',

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -105,7 +105,7 @@ class SearchConfig extends Search {
      * @return string|string[] Result may be an array when a multi column placeholder is used
      */
     protected function applyFilterVars($filter) {
-        global $ID;
+        global $INFO;
 
         // apply inexpensive filters first
         $filter = str_replace(
@@ -117,9 +117,9 @@ class SearchConfig extends Search {
                 '$TODAY$'
             ),
             array(
-                $ID,
-                getNS($ID),
-                noNS($ID),
+                $INFO['id'],
+                getNS($INFO['id']),
+                noNS($INFO['id']),
                 isset($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'] : '',
                 date('Y-m-d')
             ),
@@ -141,7 +141,7 @@ class SearchConfig extends Search {
 
             // get the data from the current page
             if($table && $label) {
-                $schemaData = AccessTable::byTableName($table, $ID, 0);
+                $schemaData = AccessTable::byTableName($table, $INFO['id'], 0);
                 $data = $schemaData->getDataArray();
                 $value = $data[$label];
 

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -86,7 +86,7 @@ class syntax_plugin_struct_table extends DokuWiki_Syntax_Plugin {
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
         if(!$data) return false;
-        global $ID;
+        global $INFO;
         global $conf;
 
         try {
@@ -98,7 +98,7 @@ class syntax_plugin_struct_table extends DokuWiki_Syntax_Plugin {
             }
 
             /** @var AggregationTable $table */
-            $table = new $this->tableclass($ID, $mode, $renderer, $search);
+            $table = new $this->tableclass($INFO['id'], $mode, $renderer, $search);
             $table->render();
 
             if($mode == 'metadata') {


### PR DESCRIPTION
By replacing `$ID` with `$INFO['id']` the entries now work in sidebars and
especially in the new footers (see SPR-699) as expected.

Tested:
* Sorting
* Dynamic filters
* `$STRUCT.tablename.field$` placeholder
* `$ID$` placeholders

 SPR-348