### PR TITLE
use actual number of columns for pagination colspan

### DIFF
--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -429,7 +429,7 @@ class AggregationTable {
 
         $this->renderer->info['struct_table_meta'] = true;
         $this->renderer->tablerow_open();
-        $this->renderer->tableheader_open((count($this->data['cols']) + ($this->data['rownumbers'] ? 1 : 0)));
+        $this->renderer->tableheader_open((count($this->columns) + ($this->data['rownumbers'] ? 1 : 0)));
         $offset = $this->data['offset'];
 
         // prev link

--- a/style.less
+++ b/style.less
@@ -246,6 +246,10 @@ form.struct_newschema {
             &.sort-down::before {
                 content: '↓';
             }
+
+            &.next {
+                float: right;
+            }
         }
 
         input {


### PR DESCRIPTION
`$this->data['cols']` holds the number of cols defined in the syntax, which may be different from the displayed cols because the `*` might be used which counts only as 1 in data['cols'] or there might be columns defined in the syntax which are not part of the schemas and are hence not displayed.

Fixes #217 and fixes SPR-711