### PR TITLE
Add list aggregation

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -71,6 +71,7 @@ $lang['Validation Exception invalid date format'] = 'must be of format YYYY-MM-D
 $lang['Validation Exception invalid datetime format'] = 'must be of format YYYY-MM-DD HH:MM:SS';
 $lang['Validation Exception bad color specification'] = 'must be of format #RRGGBB';
 
+$lang['Exception illegal option'] = 'The option \'<code>%s</code>\' is invalid for this aggregation type.';
 $lang['Exception noschemas'] = 'There have been no schemas given to load columns from';
 $lang['Exception nocolname'] = 'No column name given';
 $lang['Exception nolookupmix'] = 'You can not aggregate more than one Lookup or mix it with Page data';

--- a/meta/AggregationList.php
+++ b/meta/AggregationList.php
@@ -138,7 +138,7 @@ class AggregationList {
             }
             $value->render($this->renderer, $this->mode);
             if ($column < $this->resultColumnCount) {
-                $this->renderer->doc .= ' ';
+                $this->renderer->cdata(' ');
             }
             if ($this->mode == 'xhtml') {
                 $this->renderer->doc .= '</div>';

--- a/meta/AggregationList.php
+++ b/meta/AggregationList.php
@@ -72,13 +72,17 @@ class AggregationList {
 
         $this->startScope();
 
-        $this->renderer->doc .= '<ul>';
+        $this->renderer->listu_open();
 
         foreach ($this->result as $result) {
+            $this->renderer->listitem_open(1);
+            $this->renderer->listcontent_open();
             $this->renderListItem($result);
+            $this->renderer->listcontent_close();
+            $this->renderer->listitem_close();
         }
 
-        $this->renderer->doc .= '</ul>';
+        $this->renderer->listu_close();
 
         $this->finishScope();
 
@@ -111,7 +115,6 @@ class AggregationList {
      * @param $resultrow
      */
     protected function renderListItem($resultrow) {
-        $this->renderer->doc .= '<li><div class="li">';
         $sepbyheaders = $this->searchConfig->getConf()['sepbyheaders'];
         $headers = $this->searchConfig->getConf()['headers'];
 
@@ -123,17 +126,24 @@ class AggregationList {
                 continue;
             }
             if ($sepbyheaders && !empty($headers[$column])) {
-                $this->renderer->doc .= '<span class="struct_header">' . hsc($headers[$column]) . '</span>';
+                if ($this->mode == 'xhtml') {
+                    $this->renderer->doc .= '<span class="struct_header">' . hsc($headers[$column]) . '</span>';
+                } else {
+                    $this->renderer->cdata($headers[$column]);
+                }
             }
-            $type = 'struct_' . strtolower($value->getColumn()->getType()->getClass());
-            $this->renderer->doc .= '<div class="' . $type . '">';
+            if ($this->mode == 'xhtml') {
+                $type = 'struct_' . strtolower($value->getColumn()->getType()->getClass());
+                $this->renderer->doc .= '<div class="' . $type . '">';
+            }
             $value->render($this->renderer, $this->mode);
             if ($column < $this->resultColumnCount) {
                 $this->renderer->doc .= ' ';
             }
-            $this->renderer->doc .= '</div>';
+            if ($this->mode == 'xhtml') {
+                $this->renderer->doc .= '</div>';
+            }
         }
 
-        $this->renderer->doc .= '</div></li>';
     }
 }

--- a/meta/AggregationList.php
+++ b/meta/AggregationList.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+
+/**
+ * Class AggregationList
+ *
+ * @package dokuwiki\plugin\struct\meta
+ */
+class AggregationList {
+
+    /**
+     * @var string the page id of the page this is rendered to
+     */
+    protected $id;
+    /**
+     * @var string the Type of renderer used
+     */
+    protected $mode;
+    /**
+     * @var \Doku_Renderer the DokuWiki renderer used to create the output
+     */
+    protected $renderer;
+    /**
+     * @var SearchConfig the configured search - gives access to columns etc.
+     */
+    protected $searchConfig;
+
+    /**
+     * @var Column[] the list of columns to be displayed
+     */
+    protected $columns;
+
+    /**
+     * @var  Value[][] the search result
+     */
+    protected $result;
+
+    /**
+     * @var int number of all results
+     */
+    protected $resultColumnCount;
+
+    /**
+     * Initialize the Aggregation renderer and executes the search
+     *
+     * You need to call @see render() on the resulting object.
+     *
+     * @param string $id
+     * @param string $mode
+     * @param \Doku_Renderer $renderer
+     * @param SearchConfig $searchConfig
+     */
+    public function __construct($id, $mode, \Doku_Renderer $renderer, SearchConfig $searchConfig) {
+        $this->id = $id;
+        $this->mode = $mode;
+        $this->renderer = $renderer;
+        $this->searchConfig = $searchConfig;
+        $this->data = $searchConfig->getConf();
+        $this->columns = $searchConfig->getColumns();
+
+        $this->result = $this->searchConfig->execute();
+        $this->resultColumnCount = count($this->columns);
+        $this->resultPIDs = $this->searchConfig->getPids();
+    }
+
+    /**
+     * Create the list on the renderer
+     */
+    public function render() {
+
+        $this->startScope();
+
+        $this->renderer->doc .= '<ul>';
+
+        foreach ($this->result as $result) {
+            $this->renderListItem($result);
+        }
+
+        $this->renderer->doc .= '</ul>';
+
+        $this->finishScope();
+
+        return;
+    }
+
+    /**
+     * Adds additional info to document and renderer in XHTML mode
+     *
+     * @see finishScope()
+     */
+    protected function startScope() {
+        // wrapping div
+        if($this->mode != 'xhtml') return;
+        $this->renderer->doc .= "<div class=\"structaggregation listaggregation\">";
+    }
+
+    /**
+     * Closes anything opened in startScope()
+     *
+     * @see startScope()
+     */
+    protected function finishScope() {
+        // wrapping div
+        if($this->mode != 'xhtml') return;
+        $this->renderer->doc .= '</div>';
+    }
+
+    /**
+     * @param $resultrow
+     */
+    protected function renderListItem($resultrow) {
+        $this->renderer->doc .= '<li><div class="li">';
+        $sepbyheaders = $this->searchConfig->getConf()['sepbyheaders'];
+        $headers = $this->searchConfig->getConf()['headers'];
+
+        /**
+         * @var Value $value
+         */
+        foreach ($resultrow as $column => $value) {
+            if ($value->isEmpty()) {
+                continue;
+            }
+            if ($sepbyheaders && !empty($headers[$column])) {
+                $this->renderer->doc .= '<span class="struct_header">' . hsc($headers[$column]) . '</span>';
+            }
+            $type = 'struct_' . strtolower($value->getColumn()->getType()->getClass());
+            $this->renderer->doc .= '<div class="' . $type . '">';
+            $value->render($this->renderer, $this->mode);
+            if ($column < $this->resultColumnCount) {
+                $this->renderer->doc .= ' ';
+            }
+            $this->renderer->doc .= '</div>';
+        }
+
+        $this->renderer->doc .= '</div></li>';
+    }
+}

--- a/meta/ConfigParser.php
+++ b/meta/ConfigParser.php
@@ -55,6 +55,9 @@ class ConfigParser {
                 case 'col':
                     $this->config['cols'] = $this->parseValues($val);
                     break;
+                case 'sepbyheaders':
+                    $this->config['sepbyheaders'] = (bool) $val;
+                    break;
                 case 'head':
                 case 'header':
                 case 'headers':

--- a/style.less
+++ b/style.less
@@ -236,17 +236,12 @@ form.struct_newschema {
  */
 .dokuwiki .structaggregation {
 
-    &.listaggregation {
-        > ul li {
-            div {
-                display: inline;
+    &.listaggregation > ul li div {
+        display: inline;
 
-                p {
-                    display: inline;
-                    margin: 0;
-                }
-
-            }
+        p {
+            display: inline;
+            margin: 0;
         }
     }
 

--- a/style.less
+++ b/style.less
@@ -235,6 +235,21 @@ form.struct_newschema {
  * Aggregation
  */
 .dokuwiki .structaggregation {
+
+    &.listaggregation {
+        > ul li {
+            div {
+                display: inline;
+
+                p {
+                    display: inline;
+                    margin: 0;
+                }
+
+            }
+        }
+    }
+
     table th {
         a {
             color: @ini_link;


### PR DESCRIPTION
The goal of this pull-request is to implement the functionality of the data plugin's [`datalist`](https://www.dokuwiki.org/plugin:data#data_list_output) output style.

See #90 and see SPR-710

ToDo
-------
- [x] implement `sepbyheaders`-option?
- [x] ~~tests?~~ (there is not really meaningful business logic here
- [x] remove table-specific functionality and optionally show an error instead