### PR TITLE
Resolve conflict between type\Page and meta\Page

### DIFF
--- a/_test/Type_Dropdown.test.php
+++ b/_test/Type_Dropdown.test.php
@@ -2,7 +2,6 @@
 
 namespace dokuwiki\plugin\struct\test;
 
-use dokuwiki\plugin\struct\meta\Page;
 use dokuwiki\plugin\struct\test\mock\AccessTable;
 use dokuwiki\plugin\struct\test\mock\Dropdown;
 

--- a/_test/Type_Lookup.test.php
+++ b/_test/Type_Lookup.test.php
@@ -16,16 +16,16 @@ class Type_Lookup_struct_test extends StructTest {
 
     protected function prepareLookup() {
         saveWikiText('title1', 'test', 'test');
-        $title = new PageMeta('title1');
-        $title->setTitle('This is a title');
+        $pageMeta = new PageMeta('title1');
+        $pageMeta->setTitle('This is a title');
 
         saveWikiText('title2', 'test', 'test');
-        $title = new PageMeta('title2');
-        $title->setTitle('This is a 2nd title');
+        $pageMeta = new PageMeta('title2');
+        $pageMeta->setTitle('This is a 2nd title');
 
         saveWikiText('title3', 'test', 'test');
-        $title = new PageMeta('title3');
-        $title->setTitle('Another Title');
+        $pageMeta = new PageMeta('title3');
+        $pageMeta->setTitle('Another Title');
 
         $this->loadSchemaJSON('pageschema', '', 0, true);
         $access = AccessTable::byTableName('pageschema', 0);

--- a/_test/Type_Lookup.test.php
+++ b/_test/Type_Lookup.test.php
@@ -2,7 +2,7 @@
 
 namespace dokuwiki\plugin\struct\test;
 
-use dokuwiki\plugin\struct\meta\Page;
+use dokuwiki\plugin\struct\meta\PageMeta;
 use dokuwiki\plugin\struct\test\mock\AccessTable;
 use dokuwiki\plugin\struct\test\mock\Lookup;
 
@@ -16,15 +16,15 @@ class Type_Lookup_struct_test extends StructTest {
 
     protected function prepareLookup() {
         saveWikiText('title1', 'test', 'test');
-        $title = new Page('title1');
+        $title = new PageMeta('title1');
         $title->setTitle('This is a title');
 
         saveWikiText('title2', 'test', 'test');
-        $title = new Page('title2');
+        $title = new PageMeta('title2');
         $title->setTitle('This is a 2nd title');
 
         saveWikiText('title3', 'test', 'test');
-        $title = new Page('title3');
+        $title = new PageMeta('title3');
         $title->setTitle('Another Title');
 
         $this->loadSchemaJSON('pageschema', '', 0, true);

--- a/_test/Type_Page.test.php
+++ b/_test/Type_Page.test.php
@@ -30,15 +30,15 @@ class Type_Page_struct_test extends StructTest {
     public function test_sort() {
 
         saveWikiText('title1', 'test', 'test');
-        $title = new \dokuwiki\plugin\struct\meta\Page('title1');
+        $title = new \dokuwiki\plugin\struct\meta\PageMeta('title1');
         $title->setTitle('This is a title');
 
         saveWikiText('title2', 'test', 'test');
-        $title = new \dokuwiki\plugin\struct\meta\Page('title2');
+        $title = new \dokuwiki\plugin\struct\meta\PageMeta('title2');
         $title->setTitle('This is a title');
 
         saveWikiText('title3', 'test', 'test');
-        $title = new \dokuwiki\plugin\struct\meta\Page('title3');
+        $title = new \dokuwiki\plugin\struct\meta\PageMeta('title3');
         $title->setTitle('Another Title');
 
 
@@ -77,9 +77,9 @@ class Type_Page_struct_test extends StructTest {
         );
 
         // make sure titles for some pages are known (not for wiki:welcome)
-        $title = new \dokuwiki\plugin\struct\meta\Page('wiki:dokuwiki');
+        $title = new \dokuwiki\plugin\struct\meta\PageMeta('wiki:dokuwiki');
         $title->setTitle('DokuWiki Overview');
-        $title = new \dokuwiki\plugin\struct\meta\Page('wiki:syntax');
+        $title = new \dokuwiki\plugin\struct\meta\PageMeta('wiki:syntax');
         $title->setTitle('DokuWiki Foobar Syntax');
         $title->savePageData();
 

--- a/_test/Type_Page.test.php
+++ b/_test/Type_Page.test.php
@@ -30,16 +30,16 @@ class Type_Page_struct_test extends StructTest {
     public function test_sort() {
 
         saveWikiText('title1', 'test', 'test');
-        $title = new \dokuwiki\plugin\struct\meta\PageMeta('title1');
-        $title->setTitle('This is a title');
+        $pageMeta = new \dokuwiki\plugin\struct\meta\PageMeta('title1');
+        $pageMeta->setTitle('This is a title');
 
         saveWikiText('title2', 'test', 'test');
-        $title = new \dokuwiki\plugin\struct\meta\PageMeta('title2');
-        $title->setTitle('This is a title');
+        $pageMeta = new \dokuwiki\plugin\struct\meta\PageMeta('title2');
+        $pageMeta->setTitle('This is a title');
 
         saveWikiText('title3', 'test', 'test');
-        $title = new \dokuwiki\plugin\struct\meta\PageMeta('title3');
-        $title->setTitle('Another Title');
+        $pageMeta = new \dokuwiki\plugin\struct\meta\PageMeta('title3');
+        $pageMeta->setTitle('Another Title');
 
 
         $this->loadSchemaJSON('pageschema');
@@ -77,11 +77,11 @@ class Type_Page_struct_test extends StructTest {
         );
 
         // make sure titles for some pages are known (not for wiki:welcome)
-        $title = new \dokuwiki\plugin\struct\meta\PageMeta('wiki:dokuwiki');
-        $title->setTitle('DokuWiki Overview');
-        $title = new \dokuwiki\plugin\struct\meta\PageMeta('wiki:syntax');
-        $title->setTitle('DokuWiki Foobar Syntax');
-        $title->savePageData();
+        $pageMeta = new \dokuwiki\plugin\struct\meta\PageMeta('wiki:dokuwiki');
+        $pageMeta->setTitle('DokuWiki Overview');
+        $pageMeta = new \dokuwiki\plugin\struct\meta\PageMeta('wiki:syntax');
+        $pageMeta->setTitle('DokuWiki Foobar Syntax');
+        $pageMeta->savePageData();
 
         // search
         $search = new Search();

--- a/action/title.php
+++ b/action/title.php
@@ -8,7 +8,7 @@
 
 // must be run within Dokuwiki
 use dokuwiki\plugin\struct\meta\StructException;
-use dokuwiki\plugin\struct\meta\Page;
+use dokuwiki\plugin\struct\meta\PageMeta;
 
 if(!defined('DOKU_INC')) die();
 
@@ -39,7 +39,7 @@ class action_plugin_struct_title extends DokuWiki_Action_Plugin {
         $id = $event->data['page'];
 
         try {
-            $page = new Page($id);
+            $page = new PageMeta($id);
 
             if(!blank($event->data['current']['title'])) {
                 $page->setTitle($event->data['current']['title']);

--- a/deleted.files
+++ b/deleted.files
@@ -1,2 +1,3 @@
 _test/Type_Integer.test.php
 types/Integer.php
+meta/Page.php

--- a/meta/PageColumn.php
+++ b/meta/PageColumn.php
@@ -18,7 +18,7 @@ class PageColumn extends Column {
      * PageColumn constructor.
      *
      * @param int $sort
-     * @param Page $type
+     * @param PageMeta $type
      * @param string $table
      */
     public function __construct($sort, Page $type, $table='') {

--- a/meta/PageMeta.php
+++ b/meta/PageMeta.php
@@ -2,7 +2,7 @@
 
 namespace dokuwiki\plugin\struct\meta;
 
-class Page {
+class PageMeta {
 
     /** @var \helper_plugin_sqlite */
     protected $sqlite;


### PR DESCRIPTION
These two classes having the same name caused an error that on some
pages: after saving the page, the page itself remained blank.

The error-log contained the following:
`
[Mon Nov 28 09:05:52 2016] [error] [client 91.65.183.141] PHP Fatal error:  Cannot use dokuwiki\\plugin\\struct\\types\\Page as Page because the name is already in use in [...]/lib/plugins/struct/meta/Search.php on line 7, referer: [...]
`

This fixes SPR-720