### PR TITLE
Preface pagename with namespace for inline diff

### DIFF
--- a/action/diff.php
+++ b/action/diff.php
@@ -40,6 +40,9 @@ class action_plugin_struct_diff extends DokuWiki_Action_Plugin {
         global $INFO;
         if($ACT != 'diff') return;
         $id = $event->data[2];
+        if (!blank($event->data[1])) {
+            $id = $event->data[1] . ':' . $id;
+        }
         $rev = $event->data[3];
         if($INFO['id'] != $id) return;
 


### PR DESCRIPTION
The event IO_WIKIPAGE_READ saves the namespace of a page in $data[1] and
only the page_name itself in $data[2]. So this code was broken for all
pages not in the root namespace.

( see https://www.dokuwiki.org/devel:event:io_wikipage_read )

However I am not sure why we even need the check `if($INFO['id'] != $id) return;`. In what circumstance would these two not be identical?

Also: we currently show the raw-values in the diff. Showing the display-values might be easier to grasp.


Fixes #232 and fixes SPR-572