### PR TITLE
first go at CSV import #239

### DIFF
--- a/admin/schemas.php
+++ b/admin/schemas.php
@@ -81,7 +81,7 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
             if(isset($_FILES['csvfile']['tmp_name'])) {
                 try {
                     new CSVImporter($table, $_FILES['csvfile']['tmp_name']);
-                    msg('CSV imported', 1);
+                    msg($this->getLang('admin_csvdone'), 1);
                 } catch(StructException $e) {
                     msg(hsc($e->getMessage()), -1);
                 }
@@ -177,15 +177,15 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
         $form->addHTML('<p>' . $this->getLang('import_warning') . '</p>');
         $form->addFieldsetClose();
 
-        $form->addFieldsetOpen($this->getLang('csvexport'));
+        $form->addFieldsetOpen($this->getLang('admin_csvexport'));
         $form->addButton('exportcsv', $this->getLang('btn_export'));
         $form->addFieldsetClose();
 
         if($schema->isLookup()) {
-            $form->addFieldsetOpen($this->getLang('csvimport'));
+            $form->addFieldsetOpen($this->getLang('admin_csvimport'));
             $form->addElement(new \dokuwiki\Form\InputElement('file', 'csvfile'));
             $form->addButton('importcsv', $this->getLang('btn_import'));
-            $form->addHTML('<p><a href="https://www.dokuwiki.org/plugin:struct:csvimport">' . $this->getLang('csv_help_link') . '</a></p>');
+            $form->addHTML('<p><a href="https://www.dokuwiki.org/plugin:struct:csvimport">' . $this->getLang('admin_csvhelp') . '</a></p>');
             $form->addFieldsetClose();
         }
 

--- a/admin/schemas.php
+++ b/admin/schemas.php
@@ -7,6 +7,7 @@
  */
 
 use dokuwiki\Form\Form;
+use dokuwiki\plugin\struct\meta\CSVExporter;
 use dokuwiki\plugin\struct\meta\CSVImporter;
 use dokuwiki\plugin\struct\meta\Schema;
 use dokuwiki\plugin\struct\meta\SchemaBuilder;
@@ -85,6 +86,14 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
                     msg(hsc($e->getMessage()), -1);
                 }
             }
+        }
+
+        // export CSV
+        if($table && $INPUT->bool('exportcsv')) {
+            header('Content-Type: text/csv');
+            header('Content-Disposition: attachment; filename="' . $table . '.csv";');
+            new CSVExporter($table);
+            exit();
         }
 
         // delete
@@ -166,6 +175,10 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
         $form->addElement(new \dokuwiki\Form\InputElement('file', 'schemafile'));
         $form->addButton('import', $this->getLang('btn_import'));
         $form->addHTML('<p>' . $this->getLang('import_warning') . '</p>');
+        $form->addFieldsetClose();
+
+        $form->addFieldsetOpen($this->getLang('csvexport'));
+        $form->addButton('exportcsv', $this->getLang('btn_export'));
         $form->addFieldsetClose();
 
         if($schema->isLookup()) {

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -86,6 +86,9 @@ $lang['prev']      = 'Previous page';
 $lang['none']      = 'Nothing found';
 $lang['csvexport'] = 'CSV Export';
 
+$lang['csvimport'] = 'Import data from a CSV file';
+$lang['csv_help_link'] = 'Please refer to the manual on CSV Import for format details.';
+
 $lang['tablefilteredby'] = 'Filtered by %s';
 $lang['tableresetfilter'] = 'Show all (remove filter/sort)';
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -86,8 +86,10 @@ $lang['prev']      = 'Previous page';
 $lang['none']      = 'Nothing found';
 $lang['csvexport'] = 'CSV Export';
 
-$lang['csvimport'] = 'Import data from a CSV file';
-$lang['csv_help_link'] = 'Please refer to the manual on CSV Import for format details.';
+$lang['admin_csvexport'] = 'Export raw data to a CSV file';
+$lang['admin_csvimport'] = 'Import raw data from a CSV file';
+$lang['admin_csvdone'] = 'CSV file imported';
+$lang['admin_csvhelp'] = 'Please refer to the manual on CSV Import for format details.';
 
 $lang['tablefilteredby'] = 'Filtered by %s';
 $lang['tableresetfilter'] = 'Show all (remove filter/sort)';

--- a/meta/CSVExporter.php
+++ b/meta/CSVExporter.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+/**
+ * Class CSVExporter
+ *
+ * exports raw schema data to CSV. For lookup schemas this data can be reimported again through
+ * CSVImporter
+ *
+ * Note this is different from syntax/csv.php
+ *
+ * @package dokuwiki\plugin\struct\meta
+ */
+class CSVExporter {
+
+    protected $islookup = false;
+
+    /**
+     * CSVImporter constructor.
+     *
+     * @throws StructException
+     * @param string $table
+     */
+    public function __construct($table) {
+
+        $search = new Search();
+        $search->addSchema($table);
+        $search->addColumn('*');
+        $result = $search->execute();
+
+        $this->islookup = $search->getSchemas()[0]->isLookup();
+        if(!$this->islookup) {
+            $pids = $search->getPids();
+        } else {
+            $pids = array();
+        }
+
+        echo $this->header($search->getColumns());
+        foreach($result as $i => $row) {
+            if(!$this->islookup) {
+                $pid = $pids[$i];
+            } else {
+                $pid = 0;
+            }
+
+            echo $this->row($row, $pid);
+        }
+    }
+
+    /**
+     * Create the header
+     *
+     * @param Column[] $columns
+     * @return string
+     */
+    protected function header($columns) {
+        $row = '';
+
+        if(!$this->islookup) {
+            $row .= $this->escape('pid');
+            $row .= ',';
+        }
+
+        foreach($columns as $i => $col) {
+            $row .= $this->escape($col->getLabel());
+            $row .= ',';
+        }
+        return rtrim($row, ',') . "\r\n";
+    }
+
+    /**
+     * Create one row of data
+     *
+     * @param Value[] $values
+     * @param string $pid pid of this row
+     * @return string
+     */
+    protected function row($values, $pid) {
+        $row = '';
+
+        if(!$this->islookup) {
+            $row .= $this->escape($pid);
+            $row .= ',';
+        }
+
+        foreach($values as $value) {
+            /** @var Value $value */
+            $val = $value->getRawValue();
+            if(is_array($val)) $val = join(',', $val);
+
+            $row .= $this->escape($val);
+            $row .= ',';
+        }
+
+        return rtrim($row, ',') . "\r\n";
+    }
+
+    /**
+     * Escapes and wraps the given string
+     *
+     * Uses doubled quotes for escaping which seems to be the standard escaping method for CSV
+     *
+     * @param string $str
+     * @return string
+     */
+    protected function escape($str) {
+        return '"' . str_replace('"', '""', $str) . '"';
+    }
+
+}

--- a/meta/CSVImporter.php
+++ b/meta/CSVImporter.php
@@ -3,9 +3,9 @@
 namespace dokuwiki\plugin\struct\meta;
 
 /**
- * Class ConfigParser
+ * Class CSVImporter
  *
- * Utilities to parse the configuration syntax into an array
+ * Imports CSV data into a lookup schema
  *
  * @package dokuwiki\plugin\struct\meta
  */

--- a/meta/CSVImporter.php
+++ b/meta/CSVImporter.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+/**
+ * Class ConfigParser
+ *
+ * Utilities to parse the configuration syntax into an array
+ *
+ * @package dokuwiki\plugin\struct\meta
+ */
+class CSVImporter {
+
+    /** @var  Schema */
+    protected $schema;
+
+    /** @var  resource */
+    protected $fh;
+
+    /** @var  \helper_plugin_sqlite */
+    protected $sqlite;
+
+    /** @var Column[] The single values to store index => col */
+    protected $columns = array();
+
+    /** @var int current line number */
+    protected $line = 0;
+
+    /**
+     * CSVImporter constructor.
+     *
+     * @throws StructException
+     * @param string $table
+     * @param string $file
+     */
+    public function __construct($table, $file) {
+        $this->fh = fopen($file, 'r');
+        if(!$this->fh) throw new StructException('Failed to open CSV file for reading');
+
+        $this->schema = new Schema($table);
+        if(!$this->schema->getId()) throw new StructException('Schema does not exist');
+
+        if(!$this->schema->isLookup()) throw new StructException('CSV import is only valid for Lookup Schemas');
+
+        /** @var \helper_plugin_struct_db $db */
+        $db = plugin_load('helper', 'struct_db');
+        $this->sqlite = $db->getDB(true);
+
+        // Do the import
+        $this->readHeaders();
+        $this->importCSV();
+    }
+
+    /**
+     * Read the CSV headers and match it with the Schema columns
+     */
+    protected function readHeaders() {
+        $header = fgetcsv($this->fh);
+        if(!$header) throw new StructException('Failed to read CSV');
+        $this->line++;
+
+        foreach($header as $i => $head) {
+            $col = $this->schema->findColumn($head);
+            if(!$col) continue;
+            if(!$col->isEnabled()) continue;
+            $this->columns[$i] = $col;
+        }
+
+        if(!$this->columns) {
+            throw new StructException('None of the CSV headers matched any of the schema\'s fields');
+        }
+    }
+
+    /**
+     * Creates the insert string for the single value table
+     *
+     * @return string
+     */
+    protected function getSQLforAllValues() {
+        $colnames = array();
+        $placeholds = array();
+        foreach($this->columns as $i => $col) {
+            $colnames[] = 'col' . $col->getColref();
+            $placeholds[] = '?';
+        }
+        $colnames = join(', ', $colnames);
+        $placeholds = join(', ', $placeholds);
+        $table = $this->schema->getTable();
+
+        return "INSERT INTO data_$table ($colnames) VALUES ($placeholds)";
+    }
+
+    /**
+     * Creates the insert string for the multi value table
+     *
+     * @return string
+     */
+    protected function getSQLforMultiValue() {
+        $table = $this->schema->getTable();
+        /** @noinspection SqlResolve */
+        return "INSERT INTO multi_$table (pid, colref, row, value) VALUES (?,?,?,?)";
+    }
+
+    /**
+     * Walks through the CSV and imports
+     */
+    protected function importCSV() {
+
+        $single = $this->getSQLforAllValues();
+        $multi = $this->getSQLforMultiValue();
+
+        $this->sqlite->query('BEGIN TRANSACTION');
+        while(($data = fgetcsv($this->fh)) !== false) {
+            $this->line++;
+            $this->importLine($data, $single, $multi);
+        }
+        $this->sqlite->query('COMMIT TRANSACTION');
+    }
+
+    /**
+     * Imports one line into the schema
+     *
+     * @param string[] $line the parsed CSV line
+     * @param string $single SQL for single table
+     * @param string $multi SQL for multi table
+     */
+    protected function importLine($line, $single, $multi) {
+        // prepare values for single value table
+        $values = array();
+        foreach($this->columns as $i => $column) {
+            if(!isset($line[$i])) throw new StructException('Missing field at CSV line %d', $this->line);
+
+            if($column->isMulti()) {
+                // multi values get split on comma
+                $line[$i] = array_map('trim', explode(',', $line[$i]));
+                $values[] = $line[$i][0];
+            } else {
+                $values[] = $line[$i];
+            }
+        }
+
+        // insert into single value table (and create pid)
+        $this->sqlite->query($single, $values);
+        $res = $this->sqlite->query('SELECT last_insert_rowid()');
+        $pid = $this->sqlite->res2single($res);
+        $this->sqlite->res_close($res);
+
+        // insert all the multi values
+        foreach($this->columns as $i => $column) {
+            if(!$column->isMulti()) continue;
+            foreach($line[$i] as $row => $value) {
+                $this->sqlite->query($multi, array($pid, $column->getColref(), $row + 1, $value));
+            }
+        }
+    }
+
+}

--- a/renderer/csv.php
+++ b/renderer/csv.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * CSV export of tabular data
+ * CSV export of tabular data generated in Aggregations
+ *
+ * Note: this is different from meta\CSVExporter
  *
  * @link https://tools.ietf.org/html/rfc4180
  * @link http://csvlint.io/


### PR DESCRIPTION
This adds CSV importing for Lookup Schemas. The format is fixed (comma
separator, " encapsulation, \ escape). The first row has to contain
headers matching the Schema's field names. Non matched fields are
ignored.

No validation is done on import. All data is stored as is and will then
bw interpreted by the different types.