### PR TITLE
Fix broken cloud tags of multi-lookup columns

### DIFF
--- a/meta/Value.php
+++ b/meta/Value.php
@@ -164,7 +164,8 @@ class Value {
      * @param int $weight
      */
     public function renderAsTagCloudLink(\Doku_Renderer $R, $mode, $page, $filterQuery, $weight) {
-        $this->column->getType()->renderTagCloudLink($this->value, $R, $mode, $page, $filterQuery, $weight);
+        $value = is_array($this->value) ? $this->value[0] : $this->value;
+        $this->column->getType()->renderTagCloudLink($value, $R, $mode, $page, $filterQuery, $weight);
     }
 
     /**


### PR DESCRIPTION
There was an error/notice, that the `json_decode()` in `\dokuwiki\plugin\struct\types\Lookup::displayValue` expects an string, not an array. The array came from the type being a multi-type.

Since we group in the SQL query by tag, cloud tags are always single values. However if the column we are creating the cloud from, is actually a multi-column then that single value is still in an array. But since that array can never contain more than 1 value we can simply take the first one.

The alternative of changing the type was considered but found not to be practical, because changing the type of a value/column is not intended. Recreating a new column and type for that value has been found to be impractical as well.