### PR TITLE
Group filters from syntax in SQL

### DIFF
--- a/_test/AccessTableDataReplacement.test.php
+++ b/_test/AccessTableDataReplacement.test.php
@@ -107,4 +107,64 @@ class AccessTableDataReplacement_struct_test extends StructTest {
         $this->assertEquals(0, count($result), 'if no pages a given, then none should be shown');
     }
 
+    public function dataProvider_DataFiltersAsSubQuery() {
+        return array(
+            array(
+                array(
+                    "filter    : data = foo"
+                ),
+                "AND (data_bar.col1 = ?)",
+                "The WHERE-clauses from page-syntax should be wrapped in parentheses"
+            ),
+            array(
+                array(
+                    "OR    : data = foo"
+                ),
+                "AND (data_bar.col1 = ?)",
+                "A single OR clause should be treated as AND clauses"
+            ),
+            array(
+                array(
+                    "filter    : data = foo",
+                    "OR        : data = bar"
+                ),
+                "AND (data_bar.col1 = ? OR data_bar.col1 = ?)",
+                "The WHERE-clauses from page-syntax should be wrapped in parentheses"
+            ),
+            array(
+                array(
+                    "OR        : data = bar",
+                    "filter    : data = foo"
+                ),
+                "AND (data_bar.col1 = ? AND data_bar.col1 = ?)",
+                "A single OR clause should be treated as AND clauses"
+            )
+        );
+    }
+
+    /**
+     * @dataProvider dataProvider_DataFiltersAsSubQuery
+     */
+    public function test_DataFiltersAsSubQuery($inputFilterLines, $expectedFilterWhere, $msg) {
+        $lines = array(
+            "schema    : bar",
+            "cols      : %pageid%, data",
+        );
+
+        $lines = array_merge($lines, $inputFilterLines);
+
+        $configParser = new meta\ConfigParser($lines);
+        $actual_config = $configParser->getConfig();
+
+        $search = new meta\SearchConfig($actual_config);
+        list($sql,) = $search->getSQL();
+        $where = array_filter(explode("\n", $sql), function ($elem) {return strpos($elem,'WHERE') !== false;});
+        $where = trim(reset($where));
+
+        $baseWhere = "WHERE  ( data_bar.pid = schema_assignments.pid AND schema_assignments.tbl = 'bar' AND schema_assignments.assigned = 1 AND GETACCESSLEVEL(data_bar.pid) > 0 AND PAGEEXISTS(data_bar.pid) = 1 AND data_bar.latest = 1 ";
+
+        $expected_where = $baseWhere . $expectedFilterWhere ." )";
+        $this->assertEquals($this->cleanWS($expected_where), $this->cleanWS($where), $msg);
+    }
+
 }

--- a/_test/QueryBuilderWhere.test.php
+++ b/_test/QueryBuilderWhere.test.php
@@ -2,6 +2,7 @@
 
 namespace dokuwiki\plugin\struct\test;
 
+use dokuwiki\plugin\struct\meta\QueryBuilder;
 use dokuwiki\plugin\struct\meta\QueryBuilderWhere;
 
 /**
@@ -11,7 +12,8 @@ use dokuwiki\plugin\struct\meta\QueryBuilderWhere;
 class QueryBuilderWhere_struct_test extends StructTest {
 
     public function test_sql() {
-        $where = new QueryBuilderWhere();
+        $QB = new QueryBuilder();
+        $where = new QueryBuilderWhere($QB);
 
         $where->whereAnd('foo = foo');
         $this->assertEquals(

--- a/_test/Type_Text.test.php
+++ b/_test/Type_Text.test.php
@@ -135,7 +135,7 @@ class Type_Text_struct_test extends StructTest {
         $QB = new QueryBuilder();
 
         $text = new Text(array('prefix' => $prefix, 'postfix' => $postfix));
-        $text->filter($QB, 'T', 'col', $comp, $val, 'AND');
+        $text->filter($QB->filters(), 'T', 'col', $comp, $val, 'AND');
 
         list($sql, $opt) = $QB->getWhereSQL();
         $this->assertEquals($this->cleanWS($e_sql), $this->cleanWS($sql));

--- a/meta/QueryBuilder.php
+++ b/meta/QueryBuilder.php
@@ -27,7 +27,7 @@ class QueryBuilder {
      * QueryBuilder constructor.
      */
     public function __construct() {
-        $this->where = new QueryBuilderWhere();
+        $this->where = new QueryBuilderWhere($this);
     }
 
     /**

--- a/meta/QueryBuilderWhere.php
+++ b/meta/QueryBuilderWhere.php
@@ -18,6 +18,7 @@ class QueryBuilderWhere {
     /**
      * Create a new WHERE clause
      *
+     * @param QueryBuilder $QB The QueryBuilder to which this where-clause belongs
      * @param string $type The type of the statement, either 'AND' or 'OR'
      * @param null|string $statement The statement or null if this should hold sub statments
      */

--- a/meta/QueryBuilderWhere.php
+++ b/meta/QueryBuilderWhere.php
@@ -12,6 +12,8 @@ class QueryBuilderWhere {
     protected $statement;
     /** @var string */
     protected $type = 'AND';
+    /** @var QueryBuilder */
+    protected $QB;
 
     /**
      * Create a new WHERE clause
@@ -19,7 +21,8 @@ class QueryBuilderWhere {
      * @param string $type The type of the statement, either 'AND' or 'OR'
      * @param null|string $statement The statement or null if this should hold sub statments
      */
-    public function __construct($type = 'AND', $statement = null) {
+    public function __construct(QueryBuilder $QB, $type = 'AND', $statement = null) {
+        $this->QB = $QB;
         $this->type = $type;
         if($statement === null) {
             $this->statement = array();
@@ -81,7 +84,7 @@ class QueryBuilderWhere {
         if($op != 'AND' && $op != 'OR') {
             throw new StructException('Bad logical operator');
         }
-        $where = new QueryBuilderWhere($op, $statement);
+        $where = new QueryBuilderWhere($this->QB, $op, $statement);
         $this->statement[] = $where;
 
         if($statement) {
@@ -89,6 +92,13 @@ class QueryBuilderWhere {
         } else {
             return $where;
         }
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    public function getQB() {
+        return $this->QB;
     }
 
     /**

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -388,6 +388,9 @@ class Search {
         }
 
         // where clauses
+        if (!empty($this->filter)) {
+            $userWHERE = $QB->filters()->where('AND');
+        }
         foreach($this->filter as $filter) {
             list($col, $value, $comp, $op) = $filter;
 
@@ -413,7 +416,7 @@ class Search {
                 $colnam = $col->getColName();
             }
 
-            $col->getType()->filter($QB, $coltbl, $colnam, $comp, $value, $op); // type based filter
+            $col->getType()->filter($userWHERE, $coltbl, $colnam, $comp, $value, $op); // type based filter
         }
 
         // sorting - we always sort by the single val column

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -381,23 +381,21 @@ abstract class AbstractBaseType {
      * Important: $value might be an array. If so, the filter should check against
      * all provided values ORed together
      *
-     * @param QueryBuilder $QB the query so far
+     * @param QueryBuilderWhere $add The where clause where statements can be added
      * @param string $tablealias The table the currently saved value(s) are stored in
      * @param string $colname The column name on above table to use in the SQL
      * @param string $comp The SQL comparator (LIKE, NOT LIKE, =, !=, etc)
      * @param string|string[] $value this is the user supplied value to compare against. might be multiple
      * @param string $op the logical operator this filter should use (AND|OR)
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         /** @var QueryBuilderWhere $add Where additionional queries are added to*/
         if(is_array($value)) {
-            $add = $QB->filters()->where($op); // sub where group
+            $add = $add->where($op); // sub where group
             $op = 'OR';
-        } else {
-            $add = $QB->filters(); // main where clause
         }
         foreach((array) $value as $item) {
-            $pl = $QB->addValue($item);
+            $pl = $add->getQB()->addValue($item);
             $add->where($op, "$tablealias.$colname $comp $pl");
         }
     }

--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -99,18 +99,19 @@ class DateTime extends Date {
     }
 
     /**
-     * @param QueryBuilder $QB
+     * @param QueryBuilderWhere $add
      * @param string $tablealias
      * @param string $colname
      * @param string $comp
      * @param string|\string[] $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         $col = "$tablealias.$colname";
 
         // when accessing the revision column we need to convert from Unix timestamp
         if(is_a($this->context,'dokuwiki\plugin\struct\meta\RevisionColumn')) {
+            $QB = $add->getQB();
             $rightalias = $QB->generateTableAlias();
             $col = "DATETIME($rightalias.lastrev, 'unixepoch', 'localtime')";
             $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");
@@ -118,10 +119,8 @@ class DateTime extends Date {
 
         /** @var QueryBuilderWhere $add Where additionional queries are added to*/
         if(is_array($value)) {
-            $add = $QB->filters()->where($op); // sub where group
+            $add = $add->where($op); // sub where group
             $op = 'OR';
-        } else {
-            $add = $QB->filters(); // main where clause
         }
         foreach((array) $value as $item) {
             $pl = $QB->addValue($item);

--- a/types/Decimal.php
+++ b/types/Decimal.php
@@ -119,23 +119,21 @@ class Decimal extends AbstractMultiBaseType {
     /**
      * Decimals need to be casted to proper type for comparison
      *
-     * @param QueryBuilder $QB
+     * @param QueryBuilderWhere $add
      * @param string $tablealias
      * @param string $colname
      * @param string $comp
      * @param string|\string[] $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         /** @var QueryBuilderWhere $add Where additionional queries are added to*/
         if(is_array($value)) {
-            $add = $QB->filters()->where($op); // sub where group
+            $add = $add->where($op); // sub where group
             $op = 'OR';
-        } else {
-            $add = $QB->filters(); // main where clause
         }
         foreach((array) $value as $item) {
-            $pl = $QB->addValue($item);
+            $pl = $add->getQB()->addValue($item);
             $add->where($op, "CAST($tablealias.$colname AS DECIMAL) $comp CAST($pl AS DECIMAL)");
         }
     }

--- a/types/Lookup.php
+++ b/types/Lookup.php
@@ -3,6 +3,7 @@ namespace dokuwiki\plugin\struct\types;
 
 use dokuwiki\plugin\struct\meta\Column;
 use dokuwiki\plugin\struct\meta\QueryBuilder;
+use dokuwiki\plugin\struct\meta\QueryBuilderWhere;
 use dokuwiki\plugin\struct\meta\Schema;
 use dokuwiki\plugin\struct\meta\Search;
 use dokuwiki\plugin\struct\meta\Value;
@@ -195,29 +196,30 @@ class Lookup extends Dropdown {
     /**
      * Compare against lookup table
      *
-     * @param QueryBuilder $QB
+     * @param QueryBuilderWhere $add
      * @param string $tablealias
      * @param string $colname
      * @param string $comp
      * @param string|\string[] $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         $schema = 'data_' . $this->config['schema'];
         $column = $this->getLookupColumn();
         if(!$column) {
-            parent::filter($QB, $tablealias, $colname, $comp, $value, $op);
+            parent::filter($add, $tablealias, $colname, $comp, $value, $op);
             return;
         }
         $field = $column->getColName();
 
         // compare against lookup field
+        $QB = $add->getQB();
         $rightalias = $QB->generateTableAlias();
         $QB->addLeftJoin(
             $tablealias, $schema, $rightalias,
             "$tablealias.$colname = $rightalias.pid AND $rightalias.latest = 1"
         );
-        $column->getType()->filter($QB, $rightalias, $field, $comp, $value, $op);
+        $column->getType()->filter($add, $rightalias, $field, $comp, $value, $op);
     }
 
     /**

--- a/types/Page.php
+++ b/types/Page.php
@@ -2,6 +2,7 @@
 namespace dokuwiki\plugin\struct\types;
 
 use dokuwiki\plugin\struct\meta\QueryBuilder;
+use dokuwiki\plugin\struct\meta\QueryBuilderWhere;
 
 /**
  * Class Page
@@ -187,24 +188,25 @@ class Page extends AbstractMultiBaseType {
     /**
      * When using titles, we need to compare against the title table, too
      *
-     * @param QueryBuilder $QB
+     * @param QueryBuilderWhere $add
      * @param string $tablealias
      * @param string $colname
      * @param string $comp
      * @param string $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         if(!$this->config['usetitles']) {
-            parent::filter($QB, $tablealias, $colname, $comp, $value, $op);
+            parent::filter($add, $tablealias, $colname, $comp, $value, $op);
             return;
         }
 
+        $QB = $add->getQB();
         $rightalias = $QB->generateTableAlias();
         $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.$colname = $rightalias.pid");
 
         // compare against page and title
-        $sub = $QB->filters()->where($op);
+        $sub = $add->where($op);
         $pl = $QB->addValue($value);
         $sub->whereOr("$tablealias.$colname $comp $pl");
         $pl = $QB->addValue($value);

--- a/types/Tag.php
+++ b/types/Tag.php
@@ -105,16 +105,14 @@ class Tag extends AbstractMultiBaseType {
      * @param string|string[] $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         /** @var QueryBuilderWhere $add Where additionional queries are added to*/
         if(is_array($value)) {
-            $add = $QB->filters()->where($op); // sub where group
+            $add = $add->where($op); // sub where group
             $op = 'OR';
-        } else {
-            $add = $QB->filters(); // main where clause
         }
         foreach((array) $value as $item) {
-            $pl = $QB->addValue($item);
+            $pl = $add->getQB()->addValue($item);
             $add->where($op, "LOWER(REPLACE($tablealias.$colname, ' ', '')) $comp LOWER(REPLACE($pl, ' ', ''))");
         }
     }

--- a/types/Text.php
+++ b/types/Text.php
@@ -27,21 +27,20 @@ class Text extends AbstractMultiBaseType {
     /**
      * Comparisons are done against the full string (including prefix/postfix)
      *
-     * @param QueryBuilder $QB
+     * @param QueryBuilderWhere $add
      * @param string $tablealias
      * @param string $colname
      * @param string $comp
      * @param string|string[] $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         /** @var QueryBuilderWhere $add Where additionional queries are added to */
         if(is_array($value)) {
-            $add = $QB->filters()->where($op); // sub where group
+            $add = $add->where($op); // sub where group
             $op = 'OR';
-        } else {
-            $add = $QB->filters(); // main where clause
         }
+        $QB = $add->getQB();
         foreach((array) $value as $item) {
             $column = "$tablealias.$colname";
 

--- a/types/User.php
+++ b/types/User.php
@@ -2,6 +2,7 @@
 namespace dokuwiki\plugin\struct\types;
 
 use dokuwiki\plugin\struct\meta\QueryBuilder;
+use dokuwiki\plugin\struct\meta\QueryBuilderWhere;
 use dokuwiki\plugin\struct\meta\StructException;
 use dokuwiki\plugin\struct\meta\ValidationException;
 
@@ -132,26 +133,27 @@ class User extends AbstractMultiBaseType {
     /**
      * When using `%lasteditor%`, we need to compare against the `title` table.
      *
-     * @param QueryBuilder $QB
+     * @param QueryBuilderWhere $add
      * @param string $tablealias
      * @param string $colname
      * @param string $comp
      * @param string|\string[] $value
      * @param string $op
      */
-    public function filter(QueryBuilder $QB, $tablealias, $colname, $comp, $value, $op) {
+    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op) {
         if(is_a($this->context,'dokuwiki\plugin\struct\meta\UserColumn')) {
+            $QB = $add->getQB();
             $rightalias = $QB->generateTableAlias();
             $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");
 
             // compare against page and title
-            $sub = $QB->filters()->where($op);
+            $sub = $add->where($op);
             $pl = $QB->addValue($value);
             $sub->whereOr("$rightalias.lasteditor $comp $pl");
             return;
         }
 
-        parent::filter($QB, $tablealias, $colname, $comp, $value, $op);
+        parent::filter($add, $tablealias, $colname, $comp, $value, $op);
     }
 
 }


### PR DESCRIPTION
The filters coming from syntax should be grouped together in a subgroup to that OR-filters cannot undo the filters on `latest=1` etc.

Since we cannot know in the `AbstractBaseType::filter` function whether there is already a subgroup for us to use or which to use, the solution was to give the correct subgroup to the filter function directly.

Instead of adding another parameter to the already long list of parameters for that function, I have chosen to give the `QueryBuilderWhere` a reference back to the original `QueryBuilder`.

Fixes SPR-744