### PR TITLE
struct output occasionally at wrong place // conflict with log and include plugins

### DIFF
--- a/_test/output.test.php
+++ b/_test/output.test.php
@@ -8,7 +8,7 @@ use dokuwiki\plugin\struct\meta;
  * @group plugin_struct
  * @group plugins
  *
- * @ covers \action_plugin_struct_output
+ * @covers \action_plugin_struct_output
  */
 class output_struct_test extends StructTest {
 
@@ -78,7 +78,7 @@ class output_struct_test extends StructTest {
         $insIncludedPage = p_cached_instructions(wikiFN($includedPage), false, $includedPage);
         $this->assertEquals('document_start', $insIncludedPage[0][0]);
         $this->assertEquals('header', $insIncludedPage[1][0]);
-        $this->assertEquals('plugin', $insIncludedPage[2][0]);
+        $this->assertEquals('plugin', $insIncludedPage[2][0], 'The struct data of a page that has been included should still be displayed when viewed on its own.');
         $this->assertEquals('struct_output', $insIncludedPage[2][1][0]);
 
     }
@@ -96,7 +96,7 @@ Log for [[page01]]:
         $instructions = p_cached_instructions(wikiFN($page), false, $page);
         $this->assertEquals('document_start', $instructions[0][0]);
         $this->assertEquals('header', $instructions[1][0]);
-        $this->assertEquals('plugin', $instructions[2][0]);
+        $this->assertEquals('plugin', $instructions[2][0], 'The struct data should be rendererd after the first headline');
         $this->assertEquals('struct_output', $instructions[2][1][0]);
     }
 }

--- a/_test/output.test.php
+++ b/_test/output.test.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace dokuwiki\plugin\struct\test;
+
+use dokuwiki\plugin\struct\meta;
+
+/**
+ * @group plugin_struct
+ * @group plugins
+ *
+ * @ covers \action_plugin_struct_output
+ */
+class output_struct_test extends StructTest {
+
+    /** @var array add the extra plugins */
+    protected $pluginsEnabled = array('struct', 'sqlite', 'log', 'include');
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->loadSchemaJSON('schema1');
+        $page = 'page01';
+        $includedPage = 'foo';
+        $this->saveData(
+            $page,
+            'schema1',
+            array(
+                'first' => 'first data',
+                'second' => array('second data', 'more data', 'even more'),
+                'third' => 'third data',
+                'fourth' => 'fourth data'
+            )
+        );
+        $this->saveData(
+            $includedPage,
+            'schema1',
+            array(
+                'first' => 'first data',
+                'second' => array('second data', 'more data', 'even more'),
+                'third' => 'third data',
+                'fourth' => 'fourth data'
+            )
+        );
+    }
+
+    public function test_output() {
+        global $ID;
+        $page = 'page01';
+        $ID = $page;
+
+        saveWikiText($page, "====== abc ======\ndef",'');
+        $instructions = p_cached_instructions(wikiFN($page), false, $page);
+        $this->assertEquals('document_start', $instructions[0][0]);
+        $this->assertEquals('header', $instructions[1][0]);
+        $this->assertEquals('plugin', $instructions[2][0]);
+        $this->assertEquals('struct_output', $instructions[2][1][0]);
+    }
+
+    public function test_include_missing_output() {
+        global $ID;
+        $page = 'page01';
+        $includedPage = 'foo';
+
+        saveWikiText($page, "====== abc ======\n{{page>foo}}\n", '');
+        saveWikiText($includedPage, "====== included page ======\nqwe\n",'');
+
+
+        plugin_load('action', 'struct_output', true);
+        $ID = $page;
+        $insMainPage = p_cached_instructions(wikiFN($page), false, $page);
+        $this->assertEquals('document_start', $insMainPage[0][0]);
+        $this->assertEquals('header', $insMainPage[1][0]);
+        $this->assertEquals('plugin', $insMainPage[2][0]);
+        $this->assertEquals('struct_output', $insMainPage[2][1][0]);
+
+        plugin_load('action', 'struct_output', true);
+        $ID = $includedPage;
+        $insIncludedPage = p_cached_instructions(wikiFN($includedPage), false, $includedPage);
+        $this->assertEquals('document_start', $insIncludedPage[0][0]);
+        $this->assertEquals('header', $insIncludedPage[1][0]);
+        $this->assertEquals('plugin', $insIncludedPage[2][0]);
+        $this->assertEquals('struct_output', $insIncludedPage[2][1][0]);
+
+    }
+
+    public function test_log_conflict() {
+        global $ID;
+        $page = 'page01';
+        $ID = $page;
+
+        saveWikiText($page, "====== abc ======\n{{log}}\n", '');
+        saveWikiText($page.':log', '====== abc log ======
+Log for [[page01]]:
+
+  * 2017-02-24 10:54:13 //Example User//: foo bar','');
+        $instructions = p_cached_instructions(wikiFN($page), false, $page);
+        $this->assertEquals('document_start', $instructions[0][0]);
+        $this->assertEquals('header', $instructions[1][0]);
+        $this->assertEquals('plugin', $instructions[2][0]);
+        $this->assertEquals('struct_output', $instructions[2][1][0]);
+    }
+}

--- a/action/output.php
+++ b/action/output.php
@@ -38,10 +38,7 @@ class action_plugin_struct_output extends DokuWiki_Action_Plugin {
      * @param $param
      */
     public function handle_output(Doku_Event $event, $param) {
-        global $ID, $ACT;
-        if (act_clean($ACT) !== 'show') {
-            return;
-        }
+        global $ID;
         if(!page_exists($ID)) return;
         $ins = -1;
         $pos = 0;

--- a/action/output.php
+++ b/action/output.php
@@ -20,8 +20,6 @@ if(!defined('DOKU_INC')) die();
  */
 class action_plugin_struct_output extends DokuWiki_Action_Plugin {
 
-    protected $lastread = '';
-
     /**
      * Registers a callback function for a given event
      *
@@ -30,20 +28,6 @@ class action_plugin_struct_output extends DokuWiki_Action_Plugin {
      */
     public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('PARSER_HANDLER_DONE', 'AFTER', $this, 'handle_output');
-        $controller->register_hook('IO_WIKIPAGE_READ', 'AFTER', $this, 'handle_read');
-    }
-
-    /**
-     * This is kind of a hack. We want to be sure our instruction is only added when the
-     * instructions of the main page are created. There is no clear way to figure that out
-     * though. Thus we only act on when the appropriate wiki page was read from disk
-     * immediately before our call.
-     *
-     * @param Doku_Event $event
-     * @param $param
-     */
-    public function handle_read(Doku_Event $event, $param) {
-        $this->lastread = cleanID($event->data[1] . ':' . $event->data[2]);
     }
 
     /**
@@ -54,11 +38,11 @@ class action_plugin_struct_output extends DokuWiki_Action_Plugin {
      * @param $param
      */
     public function handle_output(Doku_Event $event, $param) {
-        global $ID;
-        if($this->lastread != $ID) return; // avoid nested calls
-        $this->lastread = '';
+        global $ID, $ACT;
+        if (act_clean($ACT) !== 'show') {
+            return;
+        }
         if(!page_exists($ID)) return;
-
         $ins = -1;
         $pos = 0;
         foreach($event->data->calls as $num => $call) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # we need additional plugin(s) for testing
 https://github.com/cosmocode/sqlite.git                         lib/plugins/sqlite
+https://github.com/dokufreaks/plugin-include/                   lib/plugins/include
+https://github.com/cosmocode/log                                lib/plugins/log

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -79,9 +79,13 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
      * @return bool If rendering was successful.
      */
     public function render($mode, Doku_Renderer $R, $data) {
+        global $ACT;
         global $ID;
         global $INFO;
         global $REV;
+        if (act_clean($ACT) !== 'show') {
+            return true;
+        }
         if($ID != $INFO['id']) return true;
         if(!$INFO['exists']) return true;
         if($this->hasBeenRendered) return true;


### PR DESCRIPTION
Problem description
--------------------------
Sometimes the instructions for a page's struct data is not rendered at the top of a page, but somewhere else or not at all.

The output is missing when the [log Plugin](https://www.dokuwiki.org/plugin:log) is included on the page and at least one entry has been made. If the log-plugin is followed by an included page, then the output is rendered at the head of this included page.

For an reproducible example see: https://demo.sprintdoc.de/projects:sprintdoc:start

Steps taken
---------------
I wrote some tests for the generated instructions:
  * `output_struct_test::test_output()` tests the base behavior.
  * `output_struct_test::test_log_conflict()` tests the bug described here and currently fails.
  * my first approach to fixing this was to adjust `action_plugin_struct_output` so that only the page that was read first would receive the output instructions. However that caused a bug with pages included by the include-plugin, that were suddenly missing their output of struct data. `output_struct_test::test_include_missing_output` catches that bug.



Possible solutions
-------
- find actual solution that works with both log and include plugin
- fix the problem somehow at the log plugin
- mark struct as incompatible with the log plugin


SPR-634