### PR TITLE
Add compareValue() to AbstractBaseType & Lookup

### DIFF
--- a/_test/AccessTableDataDB.test.php
+++ b/_test/AccessTableDataDB.test.php
@@ -101,13 +101,13 @@ class AccessTableDataDB_struct_test extends StructTest {
         $actual_data = $schemaData->getData();
 
         $expected_data = array(
-            array('value2.1a', 'value2.2a'),
-            'value1a',
+            'testMulitColumn' => array('value2.1a', 'value2.2a'),
+            'testcolumn' => 'value1a',
         );
 
         // assert
-        foreach($expected_data as $index => $value) {
-            $this->assertEquals($value, $actual_data[$index]->getValue());
+        foreach($expected_data as $key => $value) {
+            $this->assertEquals($value, $actual_data[$key]->getValue());
         }
     }
 
@@ -133,8 +133,8 @@ class AccessTableDataDB_struct_test extends StructTest {
         $actual_data = $schemaData->getData();
 
         $expected_data = array(
-            array('value2.1a'),
-            'value1a',
+            'testMulitColumn' => array('value2.1a'),
+            'testcolumn' => 'value1a',
         );
 
         // assert
@@ -150,8 +150,8 @@ class AccessTableDataDB_struct_test extends StructTest {
         $actual_data = $schemaData->getData();
 
         $expected_data = array(
-            array('value2.1', 'value2.2'),
-            'value1',
+            'testMulitColumn' => array('value2.1', 'value2.2'),
+            'testcolumn' => 'value1',
         );
 
         // assert
@@ -237,8 +237,8 @@ class AccessTableDataDB_struct_test extends StructTest {
         $actual_data = $schemaData->getData();
 
         // assert
-        $this->assertEquals(array(), $actual_data[0]->getValue());
-        $this->assertEquals(null, $actual_data[1]->getValue());
+        $this->assertEquals(array(), $actual_data['testMulitColumn']->getValue());
+        $this->assertEquals(null, $actual_data['testcolumn']->getValue());
     }
 
     public function test_getData_skipEmpty() {
@@ -261,7 +261,7 @@ class AccessTableDataDB_struct_test extends StructTest {
 
         // assert
         $this->assertEquals(1, count($actual_data), 'There should be only one value returned and the empty value skipped');
-        $this->assertEquals($expected_data, $actual_data[0]->getValue());
+        $this->assertEquals($expected_data, $actual_data['testMulitColumn']->getValue());
     }
 
     public function test_getDataArray_skipEmpty() {

--- a/_test/Type_Dropdown.test.php
+++ b/_test/Type_Dropdown.test.php
@@ -27,12 +27,12 @@ class Type_Dropdown_struct_test extends StructTest {
         $access = AccessTable::byTableName('dropdowns', 'test1');
         $data = $access->getData();
 
-        $this->assertEquals('John', $data[2]->getValue());
-        $this->assertEquals('John', $data[2]->getRawValue());
-        $this->assertEquals('John', $data[2]->getDisplayValue());
+        $this->assertEquals('John', $data['drop3']->getValue());
+        $this->assertEquals('John', $data['drop3']->getRawValue());
+        $this->assertEquals('John', $data['drop3']->getDisplayValue());
 
         $R = new \Doku_Renderer_xhtml();
-        $data[2]->render($R, 'xhtml');
+        $data['drop3']->render($R, 'xhtml');
         $this->assertEquals('John', $R->doc);
     }
 

--- a/_test/Type_Lookup.test.php
+++ b/_test/Type_Lookup.test.php
@@ -101,23 +101,23 @@ class Type_Lookup_struct_test extends StructTest {
         $access = AccessTable::byTableName('dropdowns', 'test1');
         $data = $access->getData();
 
-        $this->assertEquals('["1","[\\"title1\\",\\"This is a title\\"]"]', $data[0]->getValue());
-        $this->assertEquals('["1","title1"]', $data[1]->getValue());
+        $this->assertEquals('["1","[\\"title1\\",\\"This is a title\\"]"]', $data['drop1']->getValue());
+        $this->assertEquals('["1","title1"]', $data['drop2']->getValue());
 
-        $this->assertEquals('1', $data[0]->getRawValue());
-        $this->assertEquals('1', $data[1]->getRawValue());
+        $this->assertEquals('1', $data['drop1']->getRawValue());
+        $this->assertEquals('1', $data['drop2']->getRawValue());
 
-        $this->assertEquals('This is a title', $data[0]->getDisplayValue());
-        $this->assertEquals('title1', $data[1]->getDisplayValue());
+        $this->assertEquals('This is a title', $data['drop1']->getDisplayValue());
+        $this->assertEquals('title1', $data['drop2']->getDisplayValue());
 
         $R = new \Doku_Renderer_xhtml();
-        $data[0]->render($R, 'xhtml');
+        $data['drop1']->render($R, 'xhtml');
         $pq = \phpQuery::newDocument($R->doc);
         $this->assertEquals('This is a title', $pq->find('a')->text());
         $this->assertContains('title1', $pq->find('a')->attr('href'));
 
         $R = new \Doku_Renderer_xhtml();
-        $data[1]->render($R, 'xhtml');
+        $data['drop2']->render($R, 'xhtml');
         $pq = \phpQuery::newDocument($R->doc);
         $this->assertEquals('title1', $pq->find('a')->text());
         $this->assertContains('title1', $pq->find('a')->attr('href'));

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -79,7 +79,7 @@ $lang['Exception nolookupmix'] = 'You can not aggregate more than one Lookup or 
 $lang['Exception nolookupassign'] = 'You can not assign Lookup schemas to pages';
 $lang['Exception No data saved'] = 'No data saved';
 $lang['Exception no sqlite'] = 'The struct plugin requires the sqlite plugin. Please install and enable it.';
-$lang['Exception comlumn not in table'] = 'There is no column %s in schema %s.';
+$lang['Exception column not in table'] = 'There is no column %s in schema %s.';
 
 $lang['Warning: no filters for cloud'] = 'Filters are not supported for struct clouds.';
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -79,6 +79,7 @@ $lang['Exception nolookupmix'] = 'You can not aggregate more than one Lookup or 
 $lang['Exception nolookupassign'] = 'You can not assign Lookup schemas to pages';
 $lang['Exception No data saved'] = 'No data saved';
 $lang['Exception no sqlite'] = 'The struct plugin requires the sqlite plugin. Please install and enable it.';
+$lang['Exception comlumn not in table'] = 'There is no column %s in schema %s.';
 
 $lang['Warning: no filters for cloud'] = 'Filters are not supported for struct clouds.';
 

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -226,7 +226,7 @@ abstract class AccessTable {
             if($asarray) {
                 $data[$col->getLabel()] = $value->getRawValue();
             } else {
-                $data[] = $value;
+                $data[$col->getLabel()] = $value;
             }
         }
 

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -142,8 +142,8 @@ class SearchConfig extends Search {
             // get the data from the current page
             if($table && $label) {
                 $schemaData = AccessTable::byTableName($table, $INFO['id'], 0);
-                $data = $schemaData->getDataArray();
-                $value = $data[$label];
+                $data = $schemaData->getData();
+                $value = $data[$label]->getCompareValue();
 
                 if(is_array($value) && !count($value)) {
                     $value = '';

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -143,6 +143,9 @@ class SearchConfig extends Search {
             if($table && $label) {
                 $schemaData = AccessTable::byTableName($table, $INFO['id'], 0);
                 $data = $schemaData->getData();
+                if (!isset($data[$label])) {
+                    throw new StructException("comlumn not in table", $label, $table);
+                }
                 $value = $data[$label]->getCompareValue();
 
                 if(is_array($value) && !count($value)) {

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -144,7 +144,7 @@ class SearchConfig extends Search {
                 $schemaData = AccessTable::byTableName($table, $INFO['id'], 0);
                 $data = $schemaData->getData();
                 if (!isset($data[$label])) {
-                    throw new StructException("comlumn not in table", $label, $table);
+                    throw new StructException("column not in table", $label, $table);
                 }
                 $value = $data[$label]->getCompareValue();
 

--- a/meta/Value.php
+++ b/meta/Value.php
@@ -23,6 +23,9 @@ class Value {
     /** @var array|int|string */
     protected $display = null;
 
+    /** @var array|int|string */
+    protected $compare = null;
+
     /** @var bool is this a raw value only? */
     protected $rawonly = false;
 
@@ -76,6 +79,18 @@ class Value {
     }
 
     /**
+     * Access the compare value
+     *
+     * @return array|string (array on multi)
+     */
+    public function getCompareValue() {
+        if($this->rawonly) {
+            throw new StructException('Accessing comparevalue of rawonly value forbidden');
+        }
+        return $this->compare;
+    }
+
+    /**
      * Allows overwriting the current value
      *
      * Cleans the value(s) of empties
@@ -95,6 +110,7 @@ class Value {
         $this->value = array();
         $this->rawvalue = array();
         $this->display = array();
+        $this->compare = array();
 
         // remove all blanks
         foreach($value as $val) {
@@ -108,8 +124,10 @@ class Value {
             $this->rawvalue[] = $raw;
             if($israw) {
                 $this->display[] = $val;
+                $this->compare[] = $val;
             } else {
                 $this->display[] = $this->column->getType()->displayValue($val);
+                $this->compare[] = $this->column->getType()->compareValue($val);
             }
         }
 
@@ -118,6 +136,7 @@ class Value {
             $this->value = (string) array_shift($this->value);
             $this->rawvalue = (string) array_shift($this->rawvalue);
             $this->display = (string) array_shift($this->display);
+            $this->compare = (string) array_shift($this->compare);
         }
     }
 

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -444,6 +444,19 @@ abstract class AbstractBaseType {
     }
 
     /**
+     * This is the value to be used as argument to a filter for another column.
+     *
+     * In a sense this is the counterpart to the @see filter() function
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public function compareValue($value) {
+        return $this->rawValue($value);
+    }
+
+    /**
      * Validate and optionally clean a single value
      *
      * This function needs to throw a validation exception when validation fails.

--- a/types/Lookup.php
+++ b/types/Lookup.php
@@ -167,6 +167,26 @@ class Lookup extends Dropdown {
     }
 
     /**
+     * This is the value to be used as argument to a filter for another column.
+     *
+     * In a sense this is the counterpart to the @see filter() function
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public function compareValue($value) {
+        list(, $value) = json_decode($value);
+        $column = $this->getLookupColumn();
+        if($column) {
+            return $column->getType()->rawValue($value);
+        } else {
+            return '';
+        }
+    }
+
+
+    /**
      * Merge with lookup table
      *
      * @param QueryBuilder $QB


### PR DESCRIPTION
This fixes a bug, that caused the $STRUCT.table.field$ filter syntax to be broken for lookup fields.  Struct was comparing the row-id of the argument column to the raw value of the referenced column at the
filtered lookup.

There were multiple options to fix this bug:
1. Add a new function to the AbstractBaseType() that return raw value by default (this is the approach implemented by this commit)
2. Add a function to the lookup type only and use introspection to call it if it exists.
3. Do not compare the values in the referenced columns, but compare only the row-ids

The problem with approach 3: It is not possible to compare such lookup-column to any other column except lookups and this is not what we want.
Approaches 1 and 2 have different trade-offs on where additional code/complexity is created. I decided for approach 1 because it is the cleaner overall approach and we might want to use this functionality for future types as well.