### PR TITLE
Do not break migrations of other plugins

### DIFF
--- a/action/migration.php
+++ b/action/migration.php
@@ -30,6 +30,9 @@ class action_plugin_struct_migration extends DokuWiki_Action_Plugin {
      * @param $param
      */
     public function handle_migrations(Doku_Event $event, $param) {
+        if ($event->data['sqlite']->getAdapter()->getDbname() !== 'struct') {
+            return;
+        }
         $to = $event->data['to'];
 
         if(is_callable(array($this, "migration$to"))) {


### PR DESCRIPTION
It turns out that the new event `PLUGIN_SQLITE_DATABASE_UPGRADE` is visible to all plugins, whether it is their own database or not. Hence we should check that we only handle our own migration.

SPR-850