### PR TITLE
Wrap the hint in the inline editor in a p tag

### DIFF
--- a/action/inline.php
+++ b/action/inline.php
@@ -91,9 +91,9 @@ class action_plugin_struct_inline extends DokuWiki_Action_Plugin {
         echo '</label>';
         $hint = $this->column->getType()->getTranslatedHint();
         if($hint) {
-            echo '<div class="hint"><p>';
+            echo '<p class="hint">';
             echo hsc($hint);
-            echo '</p></div>';
+            echo '</p>';
         }
 
         // csrf protection

--- a/action/inline.php
+++ b/action/inline.php
@@ -91,9 +91,9 @@ class action_plugin_struct_inline extends DokuWiki_Action_Plugin {
         echo '</label>';
         $hint = $this->column->getType()->getTranslatedHint();
         if($hint) {
-            echo '<div class="hint">';
+            echo '<div class="hint"><p>';
             echo hsc($hint);
-            echo '</div>';
+            echo '</p></div>';
         }
 
         // csrf protection


### PR DESCRIPTION
For it to be read correctly by screen readers and for better styling, wrap the hint in the inline editor in a `<p>`-tag.

SPR-899