### PR TITLE
Fix ajax autocomplete

### DIFF
--- a/script/EntryEditor.js
+++ b/script/EntryEditor.js
@@ -57,7 +57,7 @@ var EntryEditor = function($form) {
     $form.find('input.struct_autocomplete').autocomplete({
         ismulti: false,
         source: function (request, cb) {
-            var name = jQuery(this.element[0]).closest('label').data('column');
+            var name = jQuery(this.element[0]).closest('div.field').find('label').first().data('column');
             var term = request.term;
             if (this.options.ismulti) {
                 term = extractLast(term);

--- a/style.less
+++ b/style.less
@@ -32,10 +32,10 @@
         }
     }
     div.field {
-        display: table-row;
+        display: block;
 
         label {
-            display: table-cell;
+            display: inline-block;
             text-align: left;
             font-weight: normal;
             width: 10em;
@@ -45,7 +45,7 @@
             }
 
             span.label {
-                display: inline-block;
+                display: block;
                 box-sizing: border-box;
                 padding-left: 0.5em;
                 padding-top: 0.25em;
@@ -58,7 +58,7 @@
             }
 
             span.label.hashint {
-                background: url(../../images/info.png) no-repeat right center;
+                background: url(../../images/info.png) no-repeat right 5px center;
             }
 
             span.input {


### PR DESCRIPTION
The name of the column for the auto-complete ajax-request is saved in a data-attribute of the label. Hence we have to adjust the jquery selectors accordingly.

This also fixes the style-issue mentioned in #305 