### PR TITLE
Add schema clear button and improve translation 

### DIFF
--- a/admin/schemas.php
+++ b/admin/schemas.php
@@ -113,6 +113,23 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
             }
         }
 
+        // clear
+        if($table && $INPUT->bool('clear')) {
+            if($table != $INPUT->str('confirm_clear')) {
+                msg($this->getLang('clear_fail'), -1);
+            } else {
+                try {
+                    $schema = new Schema($table);
+                    $schema->clear();
+                    msg($this->getLang('clear_ok'), 1);
+                    touch(action_plugin_struct_cache::getSchemaRefreshFile());
+                    send_redirect(wl($ID, array('do' => 'admin', 'page' => 'struct_schemas'), true, '&'));
+                } catch(StructException $e) {
+                    msg(hsc($e->getMessage()), -1);
+                }
+            }
+        }
+
     }
 
     /**
@@ -204,12 +221,18 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
         $form->setHiddenField('page', 'struct_schemas');
         $form->setHiddenField('table', $schema->getTable());
 
+        $form->addFieldsetOpen($this->getLang('btn_delete'));
         $form->addHTML($this->locale_xhtml('delete_intro'));
-
-        $form->addFieldsetOpen($this->getLang('tab_delete'));
         $form->addTextInput('confirm', $this->getLang('del_confirm'));
         $form->addButton('delete', $this->getLang('btn_delete'));
         $form->addFieldsetClose();
+
+        $form->addFieldsetOpen($this->getLang('btn_clear'));
+        $form->addHTML($this->locale_xhtml('clear_intro'));
+        $form->addTextInput('confirm_clear', $this->getLang('clear_confirm'));
+        $form->addButton('clear', $this->getLang('btn_clear'));
+        $form->addFieldsetClose();
+
         return $form->toHTML();
     }
 

--- a/lang/de/clear_intro.txt
+++ b/lang/de/clear_intro.txt
@@ -1,0 +1,1 @@
+**ACHTUNG:** Hiermit werden **alle** Daten gelöscht, die jemals für dieses Schema gespeichert waren. Es gibt kein Zurück!

--- a/lang/de/delete_intro.txt
+++ b/lang/de/delete_intro.txt
@@ -1,0 +1,1 @@
+**ACHTUNG:** Hiermit wird die Definition des Schemas gelöscht und **alle** Daten, die jemals für dieses Schema gespeichert waren. Es gibt kein Zurück!

--- a/lang/de/editor_edit.txt
+++ b/lang/de/editor_edit.txt
@@ -1,0 +1,12 @@
+====== Struct Schema Editor ======
+
+Schemafelder können hier hinzugefügt oder bearbeitet werden.
+
+Feldnamen müssen einzigartig sein.
+Es wird empfohlen kurze Bezeichner zu verwenden, die sich wahrscheinlich später nicht ändern werden, da später sie als Verweise auf die Felder in den Aggregationen genutzt werden.
+Das Label-Konfigurations-Feld sollte für menschen-lesbare Namen verwendet werden.
+
+Der Typ des Feldes definiert welche Informationen darin gespeichert werden und beieinflusst wie diese später angezeigt werden.
+Jeder Typ hat seine eigenen Konfigurationsoptionen.
+
+Weitere Informationen finden sich in der [[doku>plugin:struct:type|Dokumentation des Plugins]].

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -18,4 +18,15 @@ $lang['summary']               = 'Struct-Daten geändert';
 $lang['export']                = 'Schema als JSON exportieren';
 $lang['btn_export']            = 'Exportieren';
 
+$lang['del_confirm'] = 'Namen des Schema zur Bestätigung der Löschung eingeben';
+$lang['del_fail'] = 'Die Schemanamen stimmten nicht überein. Schema nicht gelöscht';
+$lang['del_ok'] = 'Schema wurde gelöscht';
+$lang['btn_delete'] = 'Löschen';
 $lang['js']['confirmAssignmentsDelete'] = 'Wollen Sie wirklich die Zuweisung von Schma "{0}" zu Seite/Namensraum "{1}" löschen?';
+
+$lang['clear_confirm'] = 'Namen des Schema zur Bestätigung der Entfernung aller Daten eingeben';
+$lang['clear_fail'] = 'Die Schemanamen stimmten nicht überein. Daten wurden nicht entfernt';
+$lang['clear_ok'] = 'Die Daten des Schemas wurden entfernt';
+$lang['btn_clear'] = 'Leeren';
+
+$lang['tab_delete'] = 'Löschen/Leeren';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -17,6 +17,9 @@ $lang['pagelabel']             = 'Seite';
 $lang['summary']               = 'Struct-Daten geändert';
 $lang['export']                = 'Schema als JSON exportieren';
 $lang['btn_export']            = 'Exportieren';
+$lang['import']                = 'Importieren eines Schemas aus JSON';
+$lang['btn_import']            = 'Importieren';
+$lang['import_warning']        = 'Achtung: dies überschriebt bereits definierte Felder!';
 
 $lang['del_confirm'] = 'Namen des Schema zur Bestätigung der Löschung eingeben';
 $lang['del_fail'] = 'Die Schemanamen stimmten nicht überein. Schema nicht gelöscht';
@@ -30,3 +33,8 @@ $lang['clear_ok'] = 'Die Daten des Schemas wurden entfernt';
 $lang['btn_clear'] = 'Leeren';
 
 $lang['tab_delete'] = 'Löschen/Leeren';
+
+$lang['admin_csvexport'] = 'Exportieren von Rohdaten in einer CSV-Datei';
+$lang['admin_csvimport'] = 'Importieren von Rohdaten aus einer CSV-Datei';
+$lang['admin_csvdone'] = 'CSV-Datei importiert';
+$lang['admin_csvhelp'] = 'Bitte konsultieren Sie das Handbuch zum CSV-Import (engl.) für Formatierungsdetails.';

--- a/lang/en/clear_intro.txt
+++ b/lang/en/clear_intro.txt
@@ -1,0 +1,1 @@
+**WARNING:** This will clear **all** data that has ever been saved for this schema! There is no going back!

--- a/lang/en/editor_edit.txt
+++ b/lang/en/editor_edit.txt
@@ -2,7 +2,7 @@
 
 Add or modify fields of the schema here.
 
-Field names have to be unique. It is recommended to use short identifiers that unlikely change later as they will beused to reference the fields in aggregations later. Use the translation labels in the field's configuration for more human readable names.
+Field names have to be unique. It is recommended to use short identifiers that unlikely change later as they will be used to reference the fields in aggregations later. Use the translation labels in the field's configuration for more human readable names.
 
 The type of a field defines what kind of data can be stored in the field and influences how it will be displayed later. Each type has its own specific configuration options.
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -36,9 +36,14 @@ $lang['del_ok'] = 'Schema has been deleted';
 $lang['btn_delete'] = 'Delete';
 $lang['js']['confirmAssignmentsDelete'] = 'Do you really want to delete the assignment of schema "{0}" to page/namespace "{1}"?';
 
+$lang['clear_confirm'] = 'Enter schema name to confirm clearing all data';
+$lang['clear_fail'] = 'Schema names did not match. Data not deleted';
+$lang['clear_ok'] = 'Data of schema has been deleted';
+$lang['btn_clear'] = 'Clear';
+
 $lang['tab_edit'] = 'Edit Schema';
 $lang['tab_export'] = 'Import/Export';
-$lang['tab_delete'] = 'Delete';
+$lang['tab_delete'] = 'Delete/Clear';
 
 $lang['editor_sort'] = 'Sort';
 $lang['editor_label'] = 'Field Name';

--- a/meta/Schema.php
+++ b/meta/Schema.php
@@ -252,6 +252,21 @@ class Schema {
         $this->ts = 0;
     }
 
+
+    /**
+     * Clear all data of a schema, but retain the schema itself
+     */
+    public function clear() {
+        if(!$this->id) throw new StructException('can not clear data of unsaved schema');
+
+        $this->sqlite->query('BEGIN TRANSACTION');
+        $sql = 'DELETE FROM ?';
+        $this->sqlite->query($sql, 'data_' . $this->table);
+        $this->sqlite->query($sql, 'multi_' . $this->table);
+        $this->sqlite->query('COMMIT TRANSACTION');
+        $this->sqlite->query('VACUUM');
+    }
+
     /**
      * @return string
      */

--- a/style.less
+++ b/style.less
@@ -144,6 +144,7 @@
 
     fieldset {
         margin-bottom: 1em;
+        width: 500px;
     }
 }
 


### PR DESCRIPTION
This pull request adds a button to clear a schema's data, but to leave the schema itself intact. This can be useful if the data is maintained externally and only imported to the wiki.

This also adds some German translations.