### PR TITLE
Allow display of struct cloud in columns 

### DIFF
--- a/meta/AggregationCloud.php
+++ b/meta/AggregationCloud.php
@@ -88,7 +88,15 @@ class AggregationCloud {
     protected function startScope() {
         // wrapping div
         if($this->mode != 'xhtml') return;
-        $this->renderer->doc .= "<div class=\"structcloud\">";
+        $params = [
+            'class' => 'structcloud',
+        ];
+        if($this->data['displaycolumns'] > 0) {
+            $params['class'] .= ' columnDisplay';
+            $params['style'] .= 'column-count: ' . $this->data['displaycolumns'] . ';';
+        }
+        $attributes = buildAttributes($params);
+        $this->renderer->doc .= "<div $attributes>";
     }
 
     /**

--- a/meta/ConfigParser.php
+++ b/meta/ConfigParser.php
@@ -37,6 +37,7 @@ class ConfigParser {
             'schemas' => array(),
             'sort' => array(),
             'csv' => true,
+            'displaycolumns' => 0,
         );
         // parse info
         foreach($lines as $line) {
@@ -113,6 +114,9 @@ class ConfigParser {
                 case 'target':
                 case 'page':
                     $this->config['target'] = cleanID($val);
+                    break;
+                case 'displaycolumns':
+                    $this->config['displaycolumns'] = abs((int) $val);
                     break;
                 default:
                     $data = array('config' => &$this->config, 'key' => $key, 'val' => $val);

--- a/style.less
+++ b/style.less
@@ -341,6 +341,12 @@ form.struct_newschema {
             box-shadow: 1px 1px 5px 1px rgba(0, 0, 0, 0.5)
         }
     }
+
+    &.columnDisplay {
+        li {
+            float: none;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
The current struct cloud can be very confusing, especially if there are many, many tags. Displaying this as a list with multiple columns might then be more helpful. 