### PR TITLE
Import csv data for page schemas #333

### DIFF
--- a/admin/schemas.php
+++ b/admin/schemas.php
@@ -181,13 +181,11 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
         $form->addButton('exportcsv', $this->getLang('btn_export'));
         $form->addFieldsetClose();
 
-        if($schema->isLookup()) {
-            $form->addFieldsetOpen($this->getLang('admin_csvimport'));
-            $form->addElement(new \dokuwiki\Form\InputElement('file', 'csvfile'));
-            $form->addButton('importcsv', $this->getLang('btn_import'));
-            $form->addHTML('<p><a href="https://www.dokuwiki.org/plugin:struct:csvimport">' . $this->getLang('admin_csvhelp') . '</a></p>');
-            $form->addFieldsetClose();
-        }
+        $form->addFieldsetOpen($this->getLang('admin_csvimport'));
+        $form->addElement(new \dokuwiki\Form\InputElement('file', 'csvfile'));
+        $form->addButton('importcsv', $this->getLang('btn_import'));
+        $form->addHTML('<p><a href="https://www.dokuwiki.org/plugin:struct:csvimport">' . $this->getLang('admin_csvhelp') . '</a></p>');
+        $form->addFieldsetClose();
 
         return $form->toHTML();
     }

--- a/admin/schemas.php
+++ b/admin/schemas.php
@@ -8,7 +8,8 @@
 
 use dokuwiki\Form\Form;
 use dokuwiki\plugin\struct\meta\CSVExporter;
-use dokuwiki\plugin\struct\meta\CSVImporter;
+use dokuwiki\plugin\struct\meta\CSVLookupImporter;
+use dokuwiki\plugin\struct\meta\CSVPageImporter;
 use dokuwiki\plugin\struct\meta\Schema;
 use dokuwiki\plugin\struct\meta\SchemaBuilder;
 use dokuwiki\plugin\struct\meta\SchemaEditor;
@@ -80,7 +81,13 @@ class admin_plugin_struct_schemas extends DokuWiki_Admin_Plugin {
         if($table && $INPUT->bool('importcsv')) {
             if(isset($_FILES['csvfile']['tmp_name'])) {
                 try {
-                    new CSVImporter($table, $_FILES['csvfile']['tmp_name']);
+                    if ($INPUT->bool('lookup')) {
+                        $csvImporter = new CSVLookupImporter($table, $_FILES['csvfile']['tmp_name']);
+                    } else {
+                        $csvImporter = new CSVPageImporter($table, $_FILES['csvfile']['tmp_name']);
+                    }
+                    $csvImporter->import();
+
                     msg($this->getLang('admin_csvdone'), 1);
                 } catch(StructException $e) {
                     msg(hsc($e->getMessage()), -1);

--- a/meta/CSVImporter.php
+++ b/meta/CSVImporter.php
@@ -124,12 +124,12 @@ abstract class CSVImporter {
         $single = $this->getSQLforAllValues();
         $multi = $this->getSQLforMultiValue();
 
-        $this->sqlite->query('BEGIN TRANSACTION');
         while(($data = fgetcsv($this->fh)) !== false) {
+            $this->sqlite->query('BEGIN TRANSACTION');
             $this->line++;
             $this->importLine($data, $single, $multi);
+            $this->sqlite->query('COMMIT TRANSACTION');
         }
-        $this->sqlite->query('COMMIT TRANSACTION');
     }
 
     /**

--- a/meta/CSVImporter.php
+++ b/meta/CSVImporter.php
@@ -179,10 +179,12 @@ abstract class CSVImporter {
     }
 
     /**
+     * INSERT $values into data_* table
+     *
      * @param string[] $values
      * @param string $single SQL for single table
      *
-     * @return string pid
+     * @return string last_insert_rowid()
      */
     protected function insertIntoSingle($values, $single) {
         $this->sqlite->query($single, $values);
@@ -194,6 +196,8 @@ abstract class CSVImporter {
     }
 
     /**
+     * INSERT one row into multi_* table
+     *
      * @param string $multi SQL for multi table
      * @param $pid string
      * @param $column string
@@ -205,6 +209,8 @@ abstract class CSVImporter {
     }
 
     /**
+     * Save one CSV line into database
+     *
      * @param string[] $values parsed line values
      * @param string $single SQL for single table
      * @param string $multi SQL for multi table

--- a/meta/CSVLookupImporter.php
+++ b/meta/CSVLookupImporter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+class CSVLookupImporter extends CSVImporter {
+
+    /**
+     * Check if schema is lookup
+     *
+     * @throws StructException
+     * @param string $table
+     * @param string $file
+     */
+    public function __construct($table, $file) {
+        parent::__construct($table, $file);
+
+        if(!$this->schema->isLookup()) throw new StructException($table.' is not lookup schema');
+    }
+
+}

--- a/meta/CSVPageImporter.php
+++ b/meta/CSVPageImporter.php
@@ -152,12 +152,6 @@ class CSVPageImporter extends CSVImporter {
                 return false;
             }
             if(page_exists($pid)) {
-                //check if schema is assigned to page
-                $tables = Assignments::getInstance()->getPageAssignments($pid, true);
-                if (!in_array($this->schema->getTable(), $tables)) {
-                    $this->errors[] = 'Schema not assigned to page "'.$pid.'"';
-                    return false;
-                }
                 $this->importedPids[$pid] = true;
                 return true;
             }

--- a/meta/CSVPageImporter.php
+++ b/meta/CSVPageImporter.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+use dokuwiki\plugin\struct\types\Page;
+
+class CSVPageImporter extends CSVImporter {
+    /**
+     * Chceck if schema is page schema
+     *
+     * @throws StructException
+     * @param string $table
+     * @param string $file
+     */
+    public function __construct($table, $file) {
+        parent::__construct($table, $file);
+
+        if($this->schema->isLookup()) throw new StructException($table.' is not a page schema');
+    }
+
+    /**
+     * Import page schema only when the pid header is present.
+     */
+    protected function readHeaders() {
+
+        //add pid to struct
+        $pageType = new Page(null, 'pid');
+        $this->columns[] = new Column(0, $pageType);
+
+        parent::readHeaders();
+
+        if(!in_array('pid', $this->header)) throw new StructException('There is no "pid" header in the CSV. Schema not imported.');
+    }
+
+    /**
+     * Creates the insert string for the single value table
+     *
+     * @return string
+     */
+    protected function getSQLforAllValues() {
+        $colnames = array();
+        foreach($this->columns as $i => $col) {
+            $colnames[] = 'col' . $col->getColref();
+        }
+        //replace first column with pid
+        $colnames[0] = 'pid';
+        //insert rev at the end
+        $colnames[] = 'rev';
+
+        $placeholds = join(', ', array_fill(0, count($colnames), '?'));
+        $colnames = join(', ', $colnames);
+        $table = $this->schema->getTable();
+
+        //replace previous data
+        return "REPLACE INTO data_$table ($colnames, latest) VALUES ($placeholds, 1)";
+    }
+
+    /**
+     * Add the revision.
+     *
+     * @param string[] $values
+     * @param          $line
+     * @param string   $single
+     * @param string   $multi
+     */
+    protected function saveLine($values, $line, $single, $multi) {
+        //read the lastest revision of inserted page
+        $values[] = @filemtime(wikiFN($values[0]));
+        parent::saveLine($values, $line, $single, $multi);
+    }
+
+    /**
+     * In the paga schemas primary key is a touple of (pid, rev)
+     *
+     * @param string[] $values
+     * @param string   $single
+     * @return array(pid, rev)
+     */
+    protected function insertIntoSingle($values, $single) {
+        parent::insertIntoSingle($values, $single);
+        $pid = $values[0];
+        $rev = $values[count($values) - 1];
+        //primary key is touple of (pid, rev)
+        return array($pid, $rev);
+    }
+
+    /**
+     * Add pid and rev to insert query parameters
+     *
+     * @param string $multi
+     * @param string $pk
+     * @param string $column
+     * @param string $row
+     * @param string $value
+     */
+    protected function insertIntoMulti($multi, $pk, $column, $row, $value) {
+        list($pid, $rev) = $pk;
+        $this->sqlite->query($multi, array($pid, $rev, $column->getColref(), $row + 1, $value));
+    }
+
+    /**
+     * In page schemas we use REPLACE instead of INSERT to prevent ambiguity
+     *
+     * @return string
+     */
+    protected function getSQLforMultiValue() {
+        $table = $this->schema->getTable();
+        /** @noinspection SqlResolve */
+        return "REPLACE INTO multi_$table (pid, rev, colref, row, value, latest) VALUES (?,?,?,?,?,1)";
+    }
+
+    /**
+     * Check if page id realy exists
+     *
+     * @param Column $col
+     * @param mixed  $rawvalue
+     * @return bool
+     */
+    protected function validateValue(Column $col, &$rawvalue) {
+        //check if page id exists
+        if($col->getLabel() == 'pid') {
+            $rawvalue = cleanID($rawvalue);
+            if(page_exists($rawvalue)) {
+                return true;
+            }
+            $this->errors[] = 'Page "'.$rawvalue.'" does not exists. Skipping the row.';
+            return false;
+        }
+
+        return parent::validateValue($col, $rawvalue);
+    }
+}


### PR DESCRIPTION
Some important notes:
1. The "pid" column must be present in a CSV file and it's used to bound the data to a proper wiki page.
2. If the page with given "pid" not exists, we omitt the row, send the message to user but the import continues.
3. We use REPLACE instead of INSERT in SQL queries. If the page has some data already bounded, it's replaced with the CSV version. That differs from lookup schemes behavior.
4. The "rev" column is omitted in CSV file (even if present). We always REPLACE data of the latest page revision.

No unit tests were created.