### PR TITLE
Replace lookup placeholders by value not by the row id

### DIFF
--- a/_test/Bureaucracy.test.php
+++ b/_test/Bureaucracy.test.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace dokuwiki\plugin\struct\test;
+
+use dokuwiki\plugin\struct\meta;
+use dokuwiki\plugin\struct\meta\AccessTable;
+
+/**
+ * Tests for the integration with Bureaucracy plugin
+ *
+ * @group plugin_struct
+ * @group plugins
+ *
+ */
+class Bureaucracy_struct_test extends StructTest {
+
+    /** @var array alway enable the needed plugins */
+    protected $pluginsEnabled = array('struct', 'sqlite', 'bureaucracy');
+
+    /** @var array of lookup data */
+    protected $lookup = array();
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->loadSchemaJSON('bureaucracy_lookup', '', 0, true);
+        $this->loadSchemaJSON('bureaucracy');
+
+        //insert some data to lookup
+        for($i = 1; $i <= 10; ++$i) {
+            $data = array(
+                'lookup_first'  => 'value first ' . $i,
+                'lookup_second' => 'value second ' . $i
+            );
+
+            $lookupData = AccessTable::byTableName('bureaucracy_lookup', 0);
+            $lookupData->saveData($data);
+            $this->lookup[] = $lookupData;
+        }
+    }
+
+    public function test_bureaucracy_lookup_replacement_empty() {
+        //page created by bureaucracy
+        $id = 'bureaucracy_lookup_replacement_empty';
+        //id of template page
+        $template_id = 'template';
+
+        //create template
+        saveWikiText($template_id, 'Value:@@bureaucracy.lookup_select@@', 'summary');
+
+        //build form
+        $fields = array();
+
+        $lookup_field = plugin_load('helper', 'struct_field');
+        $lookup_field->opt['label'] = 'bureaucracy.lookup_select';
+        //empty value
+        $lookup_field->opt['value'] = '';
+        //left pagename undefined
+        //$lookup_field->opt['pagename'];
+
+        //$args are ommited in struct_field
+        $lookup_field->initialize(array());
+        $fields[] = $lookup_field;
+
+        //helper_plugin_bureaucracy_actiontemplate
+        $actiontemplate = plugin_load('helper', 'bureaucracy_actiontemplate');
+        $actiontemplate->run($fields, '', array($template_id, $id, '_'));
+
+        $page_content = io_readWikiPage(wikiFN($id), $id);
+
+        $this->assertEquals('Value:', $page_content);
+    }
+
+    public function test_bureaucracy_lookup_replacement() {
+        //page created by bureaucracy
+        $id = 'bureaucracy_lookup_replacement';
+        //id of template page
+        $template_id = 'template';
+        //pid of selected value
+        $lookup_pid = $this->lookup[0]->getPid();
+        //selected value
+        $lookup_value = $this->lookup[0]->getData()['lookup_first']->getValue();
+
+        //create template
+        saveWikiText($template_id, 'Value:@@bureaucracy.lookup_select@@', 'summary');
+
+        //build form
+        $fields = array();
+
+        $lookup_field = plugin_load('helper', 'struct_field');
+        $lookup_field->opt['label'] = 'bureaucracy.lookup_select';
+        $lookup_field->opt['value'] = $lookup_pid;
+        //left pagename undefined
+        //$lookup_field->opt['pagename'];
+
+        //$args are ommited in struct_field
+        $lookup_field->initialize(array());
+        $fields[] = $lookup_field;
+
+        //helper_plugin_bureaucracy_actiontemplate
+
+        $actiontemplate = plugin_load('helper', 'bureaucracy_actiontemplate');
+        $actiontemplate->run($fields, '', array($template_id, $id, '_'));
+
+        $page_content = io_readWikiPage(wikiFN($id), $id);
+
+        $this->assertEquals('Value:' . $lookup_value, $page_content);
+    }
+}

--- a/_test/json/bureaucracy.struct.json
+++ b/_test/json/bureaucracy.struct.json
@@ -1,0 +1,36 @@
+{
+    "structversion": "2017-07-11",
+    "schema": "bureaucracy",
+    "id": "2",
+    "user": "",
+    "config": {
+        "allowed editors": "",
+        "label": {
+            "en": ""
+        }
+    },
+    "columns": [
+        {
+            "colref": 1,
+            "ismulti": false,
+            "isenabled": true,
+            "sort": 10,
+            "label": "lookup_select",
+            "class": "Lookup",
+            "config": {
+                "visibility": {
+                    "inpage": true,
+                    "ineditor": true
+                },
+                "schema": "bureaucracy_lookup",
+                "field": "lookup_first",
+                "label": {
+                    "en": ""
+                },
+                "hint": {
+                    "en": ""
+                }
+            }
+        }
+    ]
+}

--- a/_test/json/bureaucracy_lookup.struct.json
+++ b/_test/json/bureaucracy_lookup.struct.json
@@ -1,0 +1,58 @@
+{
+    "structversion": "2017-07-11",
+    "schema": "bureaucracy_lookup",
+    "id": "1",
+    "user": "",
+    "config": {
+        "allowed editors": "",
+        "label": {
+            "en": ""
+        }
+    },
+    "columns": [
+        {
+            "colref": 1,
+            "ismulti": false,
+            "isenabled": true,
+            "sort": 10,
+            "label": "lookup_first",
+            "class": "Text",
+            "config": {
+                "visibility": {
+                    "inpage": true,
+                    "ineditor": true
+                },
+                "prefix": "",
+                "postfix": "",
+                "label": {
+                    "en": ""
+                },
+                "hint": {
+                    "en": ""
+                }
+            }
+        },
+        {
+            "colref": 2,
+            "ismulti": false,
+            "isenabled": true,
+            "sort": 20,
+            "label": "lookup_second",
+            "class": "Text",
+            "config": {
+                "visibility": {
+                    "inpage": true,
+                    "ineditor": true
+                },
+                "prefix": "",
+                "postfix": "",
+                "label": {
+                    "en": ""
+                },
+                "hint": {
+                    "en": ""
+                }
+            }
+        }
+    ]
+}

--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -12,6 +12,7 @@ if(!defined('DOKU_INC')) die();
 use dokuwiki\plugin\struct\meta\AccessTable;
 use dokuwiki\plugin\struct\meta\Assignments;
 use dokuwiki\plugin\struct\meta\Schema;
+use dokuwiki\plugin\struct\meta\Search;
 
 /**
  * Handles bureaucracy additions
@@ -32,6 +33,7 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin {
      * @return void
      */
     public function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('PLUGIN_BUREAUCRACY_TEMPLATE_SAVE', 'BEFORE', $this, 'handle_lookup_fields');
         $controller->register_hook('PLUGIN_BUREAUCRACY_TEMPLATE_SAVE', 'AFTER', $this, 'handle_save');
         $controller->register_hook('PLUGIN_BUREAUCRACY_FIELD_UNKNOWN', 'BEFORE', $this, 'handle_schema');
     }
@@ -68,6 +70,47 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin {
             $field->opt['label'] = $column->getFullQualifiedLabel();
             $field->column = $column;
             $event->data['fields'][] = $field;
+        }
+        return true;
+    }
+
+    /**
+     * Replace lookup fields placeholder's values
+     *
+     * @param Doku_Event $event event object by reference
+     * @param mixed $param [the parameters passed as fifth argument to register_hook() when this
+     *                           handler was registered]
+     * @return bool
+     */
+    public function handle_lookup_fields(Doku_Event $event, $param) {
+        foreach($event->data['fields'] as $field) {
+            if(!is_a($field, 'helper_plugin_struct_field')) continue;
+            if($field->column->getType()->getClass() != 'Lookup') continue;
+
+            $pid = $field->getParam('value');
+            $config = $field->column->getType()->getConfig();
+
+            // find proper value
+            // current Search implementation doesn't allow doing it using SQL
+            $search = new Search();
+            $search->addSchema($config['schema']);
+            $search->addColumn($config['field']);
+            $result = $search->execute();
+            $pids = $search->getPids();
+            $len = count($result);
+
+            $value = '';
+            for($i = 0; $i < $len; $i++) {
+                if ($pids[$i] == $pid) {
+                   $value = $result[$i][0]->getDisplayValue();
+                   break;
+                }
+            }
+
+            //replace previous value
+            if ($value) {
+                $event->data['values'][$field->column->getFullQualifiedLabel()] = $value;
+            }
         }
         return true;
     }


### PR DESCRIPTION
While creating a new page using bureaucracy template action together with struct provided data, we should replace the lookup-field's placeholders by the value selected by the user. It's much more sensible.

Fixes #323