### PR TITLE
Fix LookupEditor AJAX new entry rendering for bootstrap based templates

### DIFF
--- a/meta/LookupTable.php
+++ b/meta/LookupTable.php
@@ -56,6 +56,12 @@ class LookupTable extends AggregationTable {
      * @return string
      */
     public function getFirstRow() {
+        // XHTML renderer doesn't like calling ->tablerow_open() without
+        // ->table_open() first, since it leaves some internal variables unset.
+        // Therefore, call ->table_open() and throw away the generated HTML.
+        $this->renderer->table_open();
+        $this->renderer->doc = '';
+
         $this->renderResultRow(0, $this->result[0]);
         return $this->renderer->doc;
     }


### PR DESCRIPTION
When using a bootstrap based Dokuwiki template, new rows added in the lookup editor get displayed incorrectly after adding them to the DOM, they appear shifted to the right by one column. After a page reload, the rows display correctly.

I don't know what exactly happens on the CSS level, however the problem is, that the HTML table row returned by the AJAX lookup_save function has the CSS class "row" applied (`<tr class="row">`), which is a class defined by bootstrap having CSS rules that somehow lead to the incorrect display.

During normal table rendering using the dokuwiki XHTML renderer, the row classes have an incrementing number appended (`row1`, `row2` etc.). The row counter normally is initialized when calling `renderer->table_row()`. However this isn't called, neither directly nor indirectly, by `LookupTable->getFirstRow()`, which leads to the counter not being initialized before rendering the table row (PHP also complains about an undefined index "row_counter" if you have warnings enabled). This patch fixes that by calling `table_open()` first, discarding its result.