### PR TITLE
Feature: Configurable default values for fields

### DIFF
--- a/_test/AccessTableDataDB.test.php
+++ b/_test/AccessTableDataDB.test.php
@@ -318,4 +318,36 @@ pageschema.multititle : DokuWiki Overview, DokuWiki Foobar Syntax, wiki:welcome\
 
         $this->assertEquals($expected_pseudodiff, $actual_pseudodiff);
     }
+
+    public function test_getData_defaults() {
+        $schemaData = meta\AccessTable::byTableName('testtable', 'newpage', time());
+
+        // act
+        $actual_data = $schemaData->getData();
+
+        $expected_data = array(
+            'testcolumn' => 'defvalue1',
+            'testMulitColumn' => array('defvalue2.1', 'defvalue2.2')
+        );
+
+        // assert
+        foreach($expected_data as $key => $value) {
+            $this->assertEquals($value, $actual_data[$key]->getValue());
+        }
+    }
+
+    public function test_getDataArray_defaults() {
+        $schemaData = meta\AccessTable::byTableName('testtable', 'newpage', time());
+
+        // act
+        $actual_data = $schemaData->getDataArray();
+
+        $expected_data = array(
+            'testcolumn' => 'defvalue1',
+            'testMulitColumn' => array('defvalue2.1', 'defvalue2.2')
+        );
+
+        // assert
+        $this->assertEquals($expected_data, $actual_data, '');
+    }
 }

--- a/_test/Type_AbstractBase.test.php
+++ b/_test/Type_AbstractBase.test.php
@@ -36,7 +36,8 @@ class Type_AbstractBase_struct_test extends StructTest {
                 'hint' => array(
                     'en' => ''
                 ),
-                'visibility' => array('inpage' => true, 'ineditor' => true)
+                'visibility' => array('inpage' => true, 'ineditor' => true),
+                'default' => ''
             ),
             $type->getConfig()
         );
@@ -60,7 +61,8 @@ class Type_AbstractBase_struct_test extends StructTest {
                 'hint' => array(
                     'en' => 'english hint'
                 ),
-                'visibility' => array('inpage' => true, 'ineditor' => true)
+                'visibility' => array('inpage' => true, 'ineditor' => true),
+                'default' => ''
             ),
             $type->getConfig()
         );
@@ -93,7 +95,8 @@ class Type_AbstractBase_struct_test extends StructTest {
                     'it' => '',
                     'de' => '',
                 ),
-                'visibility' => array('inpage' => true, 'ineditor' => true)
+                'visibility' => array('inpage' => true, 'ineditor' => true),
+                'default' => ''
             ),
             $type->getConfig()
         );
@@ -133,7 +136,8 @@ class Type_AbstractBase_struct_test extends StructTest {
                     'it' => '',
                     'de' => 'german hint',
                 ),
-                'visibility' => array('inpage' => true, 'ineditor' => true)
+                'visibility' => array('inpage' => true, 'ineditor' => true),
+                'default' => ''
             ),
             $type->getConfig()
         );

--- a/_test/edit.test.php
+++ b/_test/edit.test.php
@@ -18,6 +18,7 @@ class edit_struct_test extends StructTest {
 
         $this->loadSchemaJSON('schema1');
         $this->loadSchemaJSON('schema2', 'schema2int');
+        $this->loadSchemaJSON('schema3');
         $this->saveData(
             'page01',
             'schema1',
@@ -61,6 +62,20 @@ class edit_struct_test extends StructTest {
         $this->checkField($pq, 'schema1', 'second', '');
         $this->checkField($pq, 'schema1', 'third', '');
         $this->checkField($pq, 'schema1', 'fourth', '');
+    }
+
+    public function test_createForm_defaultData() {
+        $edit = new mock\action_plugin_struct_edit();
+        global $ID;
+        $ID = 'page02';
+        $test_html = $edit->createForm('schema3');
+
+        $pq = \phpQuery::newDocument($test_html);
+        $this->assertEquals('schema3', $pq->find('legend')->text());
+        $this->checkField($pq, 'schema3', 'first', 'first');
+        $this->checkField($pq, 'schema3', 'second', 'second1, second2');
+        $this->checkField($pq, 'schema3', 'third', 'third');
+        $this->checkField($pq, 'schema3', 'fourth', 'fourth');
     }
 
     public function test_createForm_postData() {

--- a/_test/json/schema3.struct.json
+++ b/_test/json/schema3.struct.json
@@ -22,7 +22,7 @@
                     "inpage": true,
                     "ineditor": true
                 },
-                "default": "",
+                "default": "first",
                 "prefix": "",
                 "postfix": "",
                 "label": {
@@ -45,7 +45,7 @@
                     "inpage": true,
                     "ineditor": true
                 },
-                "default": "",
+                "default": "second1, second2",
                 "prefix": "",
                 "postfix": "",
                 "label": {
@@ -68,7 +68,7 @@
                     "inpage": true,
                     "ineditor": true
                 },
-                "default": "",
+                "default": "third",
                 "prefix": "",
                 "postfix": "",
                 "label": {
@@ -91,7 +91,7 @@
                     "inpage": true,
                     "ineditor": true
                 },
-                "default": "",
+                "default": "fourth",
                 "prefix": "",
                 "postfix": "",
                 "label": {

--- a/_test/json/testtable.struct.json
+++ b/_test/json/testtable.struct.json
@@ -9,6 +9,7 @@
             "label": "testcolumn",
             "class": "Text",
             "config": {
+                "default": "defvalue1",
                 "prefix": "",
                 "postfix": ""
             }
@@ -20,6 +21,7 @@
             "label": "testMulitColumn",
             "class": "Text",
             "config": {
+                "default": "defvalue2.1, defvalue2.2",
                 "prefix": "",
                 "postfix": ""
             }

--- a/helper/field.php
+++ b/helper/field.php
@@ -82,7 +82,15 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
         }
 
         // output the field
-        $value = new Value($this->column, $this->opt['value']);
+        $rawvalue = $this->opt['value'];
+        if (empty($rawvalue)) {
+            $rawvalue = $this->column->getType()->getDefaultValue();
+        }
+        if ($this->column->isMulti()) {
+            $rawvalue = explode(',', $rawvalue);
+            $rawvalue = array_map('trim', $rawvalue);
+        }
+        $value = new Value($this->column, $rawvalue);
         $field = $this->makeField($value, $params['name']);
         $form->addElement($field);
     }

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -207,14 +207,20 @@ abstract class AccessTable {
             // if no data saved yet, return empty strings
             if($DBdata) {
                 $val = $DBdata[0]['out' . $col->getColref()];
-            } else {
-                $val = '';
-            }
 
-            // multi val data is concatenated
-            if($col->isMulti()) {
-                $val = explode($sep, $val);
-                $val = array_filter($val);
+                // multi val data is concatenated
+                if($col->isMulti()) {
+                    $val = explode($sep, $val);
+                    $val = array_filter($val);
+                }
+            } else {
+                $val = $col->getType()->getDefaultValue();
+
+                // multi val data is concatenated
+                if($col->isMulti()) {
+                    $val = explode(',', $val);
+                    $val = array_map('trim', $val);
+                }
             }
 
             $value = new Value($col, $val);

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -32,7 +32,7 @@ abstract class AbstractBaseType {
     /**
      * @var array config keys that should not be cleaned despite not being in $config
      */
-    protected $keepconfig = array('label', 'hint', 'visibility');
+    protected $keepconfig = array('label', 'hint', 'visibility', 'default');
 
     /**
      * @var string label for the field
@@ -72,7 +72,8 @@ abstract class AbstractBaseType {
             'visibility' => array(
                 'inpage' => true,
                 'ineditor' => true,
-            )
+            ),
+            'default' => '',
         );
 
         // use previously saved configuration, ignoring all keys that are not supposed to be here
@@ -213,6 +214,13 @@ abstract class AbstractBaseType {
      */
     public function isVisibleInPage() {
         return $this->config['visibility']['inpage'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultValue() {
+        return $this->config['default'];
     }
 
     /**

--- a/types/Dropdown.php
+++ b/types/Dropdown.php
@@ -29,6 +29,7 @@ class Dropdown extends AbstractBaseType {
      * @return string
      */
     public function valueEditor($name, $rawvalue, $htmlID) {
+        $rawvalue = trim($rawvalue);
         $params = array(
             'name' => $name,
             'class' => 'struct_'.strtolower($this->getClass()),
@@ -60,6 +61,8 @@ class Dropdown extends AbstractBaseType {
      * @return string
      */
     public function multiValueEditor($name, $rawvalues, $htmlID) {
+        $rawvalues = array_map('trim', $rawvalues);
+        $rawvalues = array_filter($rawvalues);
         $params = array(
             'name' => $name . '[]',
             'class' => 'struct_'.strtolower($this->getClass()),


### PR DESCRIPTION
This PR adds a new "default" configuration option to fields that can be used to set a default value. The default is applied whenever no existing schema data is found for a page (for example a new page or a newly assigned schema). This also means that when adding a new field with default to a schema, the default value will not apply to already existing pages using this schema.

In addition, the default is used when adding struct fields to a bureaucracy plugin form.

If you merge this PR, please let me know once you have made a release containing the change available on dokuwiki.org, so that I can add the new option to the documentation at [https://www.dokuwiki.org/plugin:struct:type](url).