### PR TITLE
fix: struct_field in bureaucracy form now supports a default value

### DIFF
--- a/helper/field.php
+++ b/helper/field.php
@@ -43,7 +43,8 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
     protected function setVal($value) {
         if(!$this->column) {
             $value = '';
-        } else {
+        //don't validate placeholders here
+        } elseif($this->replace($value) == $value) {
             $validator = new ValueValidator();
             $this->error = !$validator->validateValue($this->column, $value);
             if($this->error) {

--- a/helper/field.php
+++ b/helper/field.php
@@ -22,7 +22,7 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
      * @param array $args
      */
     public function initialize($args) {
-        parent::initialize($args);
+        $this->init($args);
 
         // find the column
         try {
@@ -30,6 +30,8 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
         } catch(StructException $e) {
             msg(hsc($e->getMessage()), -1);
         }
+
+        $this->standardArgs($args);
     }
 
     /**


### PR DESCRIPTION
Before that we cannot use bureaucracy default values for struct_field ("=default value" syntax). Now it's possible.