### PR TITLE
fixes #351 based on zioth's suggestion

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,15 +1,22 @@
-jQuery(function () {
+jQuery(function() {
     /* DOKUWIKI:include script/functions.js */
-
     /* DOKUWIKI:include script/EntryEditor.js */
-    EntryEditor(jQuery('#dw__editform, form.bureaucracy__plugin'));
-
     /* DOKUWIKI:include script/SchemaEditor.js */
-    SchemaEditor();
-
     /* DOKUWIKI:include script/LookupEditor.js */
-    jQuery('div.structlookup table').each(LookupEditor);
-
     /* DOKUWIKI:include script/InlineEditor.js */
-    InlineEditor(jQuery('div.structaggregation table'));
+
+    function init() {
+        EntryEditor(jQuery('#dw__editform, form.bureaucracy__plugin'));
+        SchemaEditor();
+        jQuery('div.structlookup table').each(LookupEditor);
+        InlineEditor(jQuery('div.structaggregation table'));
+    }
+
+    jQuery(init);
+
+    jQuery(window).on('fastwiki:afterSwitch', function(evt, viewMode, isSectionEdit, prevViewMode) {
+        if (viewMode=="edit" || isSectionEdit) {
+            EntryEditor(jQuery('#dw__editform, form.bureaucracy__plugin'));
+        }
+    });
 });


### PR DESCRIPTION
Checked the issue and fix in my wiki. It is also necessary to react to `viewMode=="edit"` when fastwiki loads the full page's edit form. And I think, only the EntryEditor should be loaded. Otherwise I got doubled forms when doing a fastwiki section edit on a page with an lookup table form.

