### PR TITLE
add div and span fields around inline form to help the autocompletion

### DIFF
--- a/action/inline.php
+++ b/action/inline.php
@@ -87,15 +87,19 @@ class action_plugin_struct_inline extends DokuWiki_Action_Plugin {
         // output the editor
         $value = $this->schemadata->getDataColumn($this->column);
         $id = uniqid('struct__', false);
+        echo '<div class="field">';
         echo '<label data-column="' . hsc($this->column->getFullQualifiedLabel()) . '" for="' . $id . '">';
         echo '</label>';
+        echo '<span class="input">';
         echo $value->getValueEditor('entry', $id);
+        echo '</span>';
         $hint = $this->column->getType()->getTranslatedHint();
         if($hint) {
             echo '<p class="hint">';
             echo hsc($hint);
             echo '</p>';
         }
+        echo '</div>';
 
         // csrf protection
         formSecurityToken();


### PR DESCRIPTION
fixes #326 

Was caused by following line in EntryEditor.js: `var name = jQuery(this.element[0]).closest('div.field').find('label').first().data('column');`. The `div.field` was missing.