### PR TITLE
fix cleanText-reated issue form the failing unit test.

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -97,7 +97,10 @@ class action_plugin_struct_edit extends DokuWiki_Action_Plugin {
             $label = $field->getColumn()->getLabel();
             if(isset($postdata[$label])) {
                 // posted data trumps stored data
-                $field->setValue(cleanText($postdata[$label]), true);
+                $data = $postdata[$label];
+                if (is_array($data)) $data = array_map("cleanText", $data);
+                else $data = cleanText($data);
+                $field->setValue($data, true);
             }
             $html .= $this->makeField($field, self::$VAR . "[$tablename][$label]");
         }

--- a/action/edit.php
+++ b/action/edit.php
@@ -98,8 +98,11 @@ class action_plugin_struct_edit extends DokuWiki_Action_Plugin {
             if(isset($postdata[$label])) {
                 // posted data trumps stored data
                 $data = $postdata[$label];
-                if (is_array($data)) $data = array_map("cleanText", $data);
-                else $data = cleanText($data);
+                if (is_array($data)) {
+                    $data = array_map("cleanText", $data);
+                } else {
+                    $data = cleanText($data);
+                }
                 $field->setValue($data, true);
             }
             $html .= $this->makeField($field, self::$VAR . "[$tablename][$label]");


### PR DESCRIPTION
The structdata can be an array instead of a string. In that case, the previous fix would throw an assertion. This also fixes the failing unit test.

`1) dokuwiki\plugin\struct\test\edit_struct_test::test_createForm_postData
strlen() expects parameter 1 to be string, array given
/home/travis/build/cosmocode/dokuwiki-plugin-struct/inc/utf8.php:89
/home/travis/build/cosmocode/dokuwiki-plugin-struct/inc/common.php:982
/home/travis/build/cosmocode/dokuwiki-plugin-struct/lib/plugins/struct/action/edit.php:100
/home/travis/build/cosmocode/dokuwiki-plugin-struct/lib/plugins/struct/_test/mock/action_plugin_struct_edit.php:14
/home/travis/build/cosmocode/dokuwiki-plugin-struct/lib/plugins/struct/_test/edit.test.php:80`