### PR TITLE
"struct_lookup" action for bureaucracy

### DIFF
--- a/helper/lookup.php
+++ b/helper/lookup.php
@@ -38,7 +38,8 @@ class helper_plugin_struct_lookup extends helper_plugin_bureaucracy_action {
             if (!$access instanceof AccessTableLookup) continue;
 
             if(!$access->getSchema()->isEditable()) {
-                throw new StructException('lookup save error: no permission for schema');
+                msg('lookup save error: no permission for schema', -1);
+                return false;
             }
             $validator = $access->getValidator($data);
             if($validator->validate()) {

--- a/helper/lookup.php
+++ b/helper/lookup.php
@@ -1,0 +1,58 @@
+<?php
+use dokuwiki\plugin\struct\meta\AccessTable;
+use dokuwiki\plugin\struct\meta\AccessTableLookup;
+use dokuwiki\plugin\struct\meta\StructException;
+
+/**
+ * Allows adding a lookup schema as a bureaucracy action
+ *
+ */
+class helper_plugin_struct_lookup extends helper_plugin_bureaucracy_action {
+
+    /**
+     * Performs struct_lookup action
+     *
+     * @param helper_plugin_bureaucracy_field[] $fields  array with form fields
+     * @param string $thanks  thanks message
+     * @param array  $argv    array with entries: template, pagename, separator
+     * @return array|mixed
+     *
+     * @throws Exception
+     */
+    public function run($fields, $thanks, $argv) {
+        global $ID;
+
+        // get all struct values and their associated schemas
+        $tosave = array();
+        foreach($fields as $field) {
+            if(!is_a($field, 'helper_plugin_struct_field')) continue;
+            /** @var helper_plugin_struct_field $field */
+            $tbl = $field->column->getTable();
+            $lbl = $field->column->getLabel();
+            if(!isset($tosave[$tbl])) $tosave[$tbl] = array();
+            $tosave[$tbl][$lbl] = $field->getParam('value');
+        }
+
+        foreach($tosave as $table => $data) {
+            $access = AccessTable::byTableName($table, 0, 0);
+            if (!$access instanceof AccessTableLookup) continue;
+
+            if(!$access->getSchema()->isEditable()) {
+                throw new StructException('lookup save error: no permission for schema');
+            }
+            $validator = $access->getValidator($data);
+            if($validator->validate()) {
+                $validator->saveData();
+            }
+        }
+
+        // set thank you message
+        if(!$thanks) {
+            $thanks = sprintf($this->getLang('bureaucracy_action_struct_lookup_thanks'), wl($ID));
+        } else {
+            $thanks = hsc($thanks);
+        }
+
+        return $thanks;
+    }
+}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -109,4 +109,6 @@ $lang['no_lookup_for_page'] = 'You can\'t use the Lookup Editor on a page schema
 $lang['lookup new entry'] = 'Create new Entry';
 $lang['js']['lookup_delete'] = 'Delete Entry';
 
+$lang['bureaucracy_action_struct_lookup_thanks'] = 'The entry has been stored. <a href="%s">Add another entry</a>.';
+
 //Setup VIM: ex: et ts=4 :


### PR DESCRIPTION
Action allows create struct lookup entries using bureaucracy form. Syntax:
  <form>
  action struct_lookup
  ...
  </form>

<form> can contain any number of struct_field or struct_schema. Data will be saved to respective lookup schemas.