### PR TITLE
fix: use multi input in bureaucracy forms

### DIFF
--- a/helper/field.php
+++ b/helper/field.php
@@ -86,6 +86,9 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
 
         // output the field
         $value = new Value($this->column, $this->opt['value']);
+        if ($this->column->getType()->getClass() == 'Lookup') {
+            $value->setValue($this->opt['value'], true);
+        }
         $field = $this->makeField($value, $params['name']);
         $form->addElement($field);
     }


### PR DESCRIPTION
this commit fixes a bug that causes an error when submitting bureaucracy form with struct multi input.

additionally it fixes one minor bug that causes struct lookup fields loosing their selected values when a bureaucracy form was send with an error.

works only with: https://github.com/splitbrain/dokuwiki-plugin-bureaucracy/pull/226