### PR TITLE
📱 Improve style of struct bureaucracy fields

### DIFF
--- a/style.less
+++ b/style.less
@@ -93,12 +93,13 @@
     text-align: right;
 
     label {
-        display: inline-block;
-        width: 47%;
+        clear: both; // this is somehow missing in the bootstrap template
     }
 
     span {
         line-height: 2em;
+        float: left;
+        text-align: right;
     }
 
     span.label {
@@ -128,6 +129,23 @@
         label {
             text-align: left;
             line-height: 1.5em;
+        }
+    }
+}
+
+/*responsive - small screen*/
+@media (max-width: 480px) {
+    .dokuwiki form.bureaucracy__plugin div.field {
+        label {
+            text-align: left;
+
+            > span {
+                width: 100%;
+            }
+        }
+
+        span.input {
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
Especially when it comes to responsive design

This may still need some minor adjustments:

- DokuWiki Template:
  - [ ] on mobile the labels of the struct fields are on the right side, the other labels are on the left
- SprintDoc Template:
  - [ ] the normal labels are bold, the labels of the struct fields are not