### PR TITLE
IN operator in struct filter

### DIFF
--- a/_test/Search.test.php
+++ b/_test/Search.test.php
@@ -377,4 +377,32 @@ class Search_struct_test extends StructTest {
         $search->addColumn('nope.*');
         $this->assertEquals(0, count($search->getColumns()));
     }
+
+    public function test_filterValueList() {
+        $search = new mock\Search();
+
+        //simple - single quote
+        $this->assertEquals(array('test'),
+            $this->callInaccessibleMethod($search, 'parseFilterValueList', array('("test")')));
+
+        //simple - double quote
+        $this->assertEquals(array('test'),
+            $this->callInaccessibleMethod($search, 'parseFilterValueList', array("('test')")));
+
+        //many elements
+        $this->assertEquals(array('test', 'test2', '18'),
+            $this->callInaccessibleMethod($search, 'parseFilterValueList', array('("test", \'test2\', 18)')));
+
+        $str = <<<'EOD'
+("t\"est", 't\'est2', 18)
+EOD;
+        //escape sequences
+        $this->assertEquals(array('t"est', "t'est2", '18'),
+            $this->callInaccessibleMethod($search, 'parseFilterValueList', array($str)));
+
+        //numbers
+        $this->assertEquals(array('18.7', '10e5', '-100'),
+            $this->callInaccessibleMethod($search, 'parseFilterValueList', array('(18.7, 10e5, -100)')));
+
+    }
 }

--- a/meta/FilterValueListHandler.php
+++ b/meta/FilterValueListHandler.php
@@ -5,7 +5,7 @@ namespace dokuwiki\plugin\struct\meta;
 /**
  * Handler for the row value parser
  */
-class RowValueHandler {
+class FilterValueListHandler {
 
     protected $row = array();
     protected $current_row = 0;

--- a/meta/RowValueHandler.php
+++ b/meta/RowValueHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+/**
+ * Handler for the row value parser
+ */
+class RowValueHandler {
+
+    protected $row = array();
+    protected $current_row = 0;
+    protected $token = '';
+
+    /**
+     * @return array
+     */
+    public function get_row() {
+        return $this->row;
+    }
+
+    /**
+     * @param string match contains the text that was matched
+     * @param int state - the type of match made (see below)
+     * @param int pos - byte index where match was made
+     */
+    public function row($match, $state, $pos) {
+        switch ($state) {
+            // The start of the list...
+            case DOKU_LEXER_ENTER:
+                break;
+
+            // The end of the list
+            case DOKU_LEXER_EXIT:
+                $this->row[$this->current_row] = $this->token;
+                break;
+
+            case DOKU_LEXER_MATCHED:
+                $this->row[$this->current_row] = $this->token;
+                $this->token = '';
+                $this->current_row++;
+                break;
+        }
+        return true;
+    }
+
+    /**
+     * @param string match contains the text that was matched
+     * @param int state - the type of match made (see below)
+     * @param int pos - byte index where match was made
+     */
+    public function single_quote_string($match, $state, $pos) {
+        switch ($state) {
+            case DOKU_LEXER_UNMATCHED:
+                $this->token .= $match;
+                break;
+        }
+        return true;
+    }
+
+    /**
+     * @param string match contains the text that was matched
+     * @param int state - the type of match made (see below)
+     * @param int pos - byte index where match was made
+     */
+    public function escape_sequence($match, $state, $pos) {
+        //add escape character to the token
+        $this->token .= $match[1];
+        return true;
+    }
+
+    /**
+     * @param string match contains the text that was matched
+     * @param int state - the type of match made (see below)
+     * @param int pos - byte index where match was made
+     */
+    public function number($match, $state, $pos) {
+        $this->token = $match;
+        return true;
+    }
+}

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -20,7 +20,7 @@ class Search {
      * (order matters)
      */
     static public $COMPARATORS = array(
-        '<=', '>=', '=*', '=', '<', '>', '!=', '!~', '~',
+        '<=', '>=', '=*', '=', '<', '>', '!=', '!~', '~', 'IN'
     );
 
     /** @var  \helper_plugin_sqlite */
@@ -171,8 +171,49 @@ class Search {
             $value = $this->filterChangeToLike($value);
         }
 
+        if ($comp == 'IN' && !is_array($value)) {
+            $value = $this->parseRowValue($value);
+            //col IN ('a', 'b', 'c') is equal to col = 'a' OR 'col = 'b' OR col = 'c'
+            $comp = '=';
+        }
+
         // add the filter
         $this->filter[] = array($col, $value, $comp, $op);
+    }
+
+    /**
+     * Parse SQLite row value into array
+     *
+     * @param string $value
+     * @return string[]
+     */
+    protected function parseRowValue($value) {
+        $Handler = new RowValueHandler();
+        $Lexer = new \Doku_Lexer($Handler, 'base', true);
+
+        $Lexer->addEntryPattern('\(','base','row');
+        $Lexer->addPattern('\s*,\s*','row');
+        $Lexer->addExitPattern('\)','row');
+
+        $Lexer->addEntryPattern('"', 'row', 'double_quote_string');
+        $Lexer->addSpecialPattern('\\\\"','double_quote_string','escape_sequence');
+        $Lexer->addExitPattern('"', 'double_quote_string');
+
+        $Lexer->addEntryPattern("'", 'row', 'single_quote_string');
+        $Lexer->addSpecialPattern("\\\\'",'single_quote_string','escape_sequence');
+        $Lexer->addExitPattern("'", 'single_quote_string');
+
+        $Lexer->mapHandler('double_quote_string','single_quote_string');
+
+        $Lexer->addSpecialPattern('[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?','row','number');
+
+        $res = $Lexer->parse($value);
+
+        if (!$res || $Lexer->_mode->getCurrent() != 'base') {
+            throw new StructException('invalid row value syntax');
+        }
+
+        return $Handler->get_row();
     }
 
     /**

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -172,7 +172,7 @@ class Search {
         }
 
         if ($comp == 'IN' && !is_array($value)) {
-            $value = $this->parseRowValue($value);
+            $value = $this->parseFilterValueList($value);
             //col IN ('a', 'b', 'c') is equal to col = 'a' OR 'col = 'b' OR col = 'c'
             $comp = '=';
         }
@@ -187,8 +187,8 @@ class Search {
      * @param string $value
      * @return string[]
      */
-    protected function parseRowValue($value) {
-        $Handler = new RowValueHandler();
+    protected function parseFilterValueList($value) {
+        $Handler = new FilterValueListHandler();
         $Lexer = new \Doku_Lexer($Handler, 'base', true);
 
         $Lexer->addEntryPattern('\(','base','row');


### PR DESCRIPTION
This commit introduces additional comparator: "IN" into struct filter. The syntax is:
`structfield IN ("a", "b", "c")`
This is simply translated into:
`structfield = "a" OR structfield = "b" OR structfield = "c"`
I've found the IN syntax more readeable in some situations.