### PR TITLE
getSchema: fix invocation over rpc

### DIFF
--- a/remote.php
+++ b/remote.php
@@ -94,7 +94,7 @@ class remote_plugin_struct extends DokuWiki_Remote_Plugin {
      * @throws RemoteAccessDeniedException
      * @throws RemoteException
      */
-    public function getSchema($schema) {
+    public function getSchema($schema = null) {
         if(!auth_ismanager()) {
             throw new RemoteAccessDeniedException('you need to be manager to access schema info');
         }

--- a/remote.php
+++ b/remote.php
@@ -99,10 +99,9 @@ class remote_plugin_struct extends DokuWiki_Remote_Plugin {
             throw new RemoteAccessDeniedException('you need to be manager to access schema info');
         }
 
-        if(!$schema) $schema = null;
         try {
             $result = array();
-            $schemas = $this->hlp->getSchema($schema);
+            $schemas = $this->hlp->getSchema($schema ?: null);
             foreach($schemas as $name => $schema) {
                 $result[$name] = array();
                 foreach ($schema->getColumns(false) as $column) {


### PR DESCRIPTION
to list all schemas accept no parameter:

> parameter: string the schema to query, empty for all

```
[Wed Jan 02 17:05:25.959975 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP Warning:  Missing argument 1 for remote_plugin_struct::getSchema() in /usr/share/dokuwiki/lib/plugins/struct/remote.php on line 97
[Wed Jan 02 17:05:25.960609 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP Stack trace:
[Wed Jan 02 17:05:25.961279 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   1. {main}() /usr/share/dokuwiki/lib/exe/xmlrpc.php:0
[Wed Jan 02 17:05:25.961875 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   2. dokuwiki_xmlrpc_server->__construct() /usr/share/dokuwiki/lib/exe/xmlrpc.php:65
[Wed Jan 02 17:05:25.962996 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   3. IXR_Server->__construct() /usr/share/dokuwiki/lib/exe/xmlrpc.php:23
[Wed Jan 02 17:05:25.963441 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   4. IXR_Server->serve() /usr/share/dokuwiki/inc/IXR_Library.php:400
[Wed Jan 02 17:05:25.963901 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   5. dokuwiki_xmlrpc_server->call() /usr/share/dokuwiki/inc/IXR_Library.php:424
[Wed Jan 02 17:05:25.964372 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   6. RemoteAPI->call() /usr/share/dokuwiki/lib/exe/xmlrpc.php:33
[Wed Jan 02 17:05:25.964833 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   7. RemoteAPI->callPlugin() /usr/share/dokuwiki/inc/remote.php:93
[Wed Jan 02 17:05:25.965263 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   8. call_user_func_array:{/usr/share/dokuwiki/inc/remote.php:161}() /usr/share/dokuwiki/inc/remote.php:161
[Wed Jan 02 17:05:25.965628 2019] [:error] [pid 14] [client 172.23.0.1:57960] PHP   9. remote_plugin_struct->getSchema() /usr/share/dokuwiki/inc/remote.php:161
```

i called with empty arguments:
```php
print_r($client->__call('plugin.struct.getSchema', []));
```