### PR TITLE
Fix missing struct header on new bureaucracy pages

### DIFF
--- a/syntax/output.php
+++ b/syntax/output.php
@@ -83,7 +83,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         global $ID;
         global $INFO;
         global $REV;
-        if (act_clean($ACT) !== 'show') {
+        if (!in_array(act_clean($ACT), ['show', 'export_html'])) {
             return true;
         }
         if($ID != $INFO['id']) return true;


### PR DESCRIPTION
The bureaucracy plugin adds an invisible iframe that calls the
export_html mode on newly created pages, which is subsequently cached.
To ensure that the struct handler is present in this cached
HTML/instructions, we need to handle that mode as well.

This fixes #424