### PR TITLE
🐛 Fix fatal error if no sqlite adapter is available

### DIFF
--- a/helper/db.php
+++ b/helper/db.php
@@ -35,6 +35,12 @@ class helper_plugin_struct_db extends DokuWiki_Plugin {
             return;
         }
 
+        if ($this->sqlite->getAdapter() === null) {
+            if(defined('DOKU_UNITTEST')) throw new \Exception('Couldn\'t load PDO sqlite.');
+            $this->sqlite = null;
+            return;
+        }
+
         if($this->sqlite->getAdapter()->getName() != DOKU_EXT_PDO) {
             if(defined('DOKU_UNITTEST')) throw new \Exception('Couldn\'t load PDO sqlite.');
             $this->sqlite = null;


### PR DESCRIPTION
If the sqlite plugin is installed and active, but no sqlite is available to the php binary (e.g. if the extension is not installed or not enabled) then that would cause a fatal error, because getAdapter returns null and that case and trying to access getName on null doesn't work.

This should catch that case and result in a useful warning from the sqlite plugin itself.

Closes #440