### PR TITLE
Restore struct info in PDF output

### DIFF
--- a/syntax/output.php
+++ b/syntax/output.php
@@ -100,7 +100,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         $tables = $assignments->getPageAssignments($ID);
         if(!$tables) return true;
 
-        if($mode == 'xhtml') $R->doc .= self::XHTML_OPEN;
+        $R->doc .= self::XHTML_OPEN;
 
         $hasdata = false;
         foreach($tables as $table) {
@@ -142,10 +142,10 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
             $R->table_close();
         }
 
-        if($mode == 'xhtml') $R->doc .= self::XHTML_CLOSE;
+        $R->doc .= self::XHTML_CLOSE;
 
         // if no data has been output, remove empty wrapper again
-        if($mode == 'xhtml' && !$hasdata) {
+        if(!$hasdata) {
             $R->doc = substr($R->doc, 0, -1 * strlen(self::XHTML_OPEN . self::XHTML_CLOSE));
         }
 

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -100,7 +100,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         $tables = $assignments->getPageAssignments($ID);
         if(!$tables) return true;
 
-        $R->doc .= self::XHTML_OPEN;
+        if($mode == 'xhtml') $R->doc .= self::XHTML_OPEN;
 
         $hasdata = false;
         foreach($tables as $table) {
@@ -142,10 +142,10 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
             $R->table_close();
         }
 
-        $R->doc .= self::XHTML_CLOSE;
+        if($mode == 'xhtml') $R->doc .= self::XHTML_CLOSE;
 
         // if no data has been output, remove empty wrapper again
-        if(!$hasdata) {
+        if($mode == 'xhtml' && !$hasdata) {
             $R->doc = substr($R->doc, 0, -1 * strlen(self::XHTML_OPEN . self::XHTML_CLOSE));
         }
 

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -83,7 +83,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         global $ID;
         global $INFO;
         global $REV;
-        if (!in_array(act_clean($ACT), ['show', 'export_html'])) {
+        if (!in_array(act_clean($ACT), ['show', 'export_html', 'export_pdf'])) {
             return true;
         }
         if($ID != $INFO['id']) return true;

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -71,7 +71,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
     /**
      * Render schema data
      *
-     * No output with renderers other than descendants of Doku_Renderer_xhtml
+     * Currently completely renderer agnostic
      *
      * @param string $mode Renderer mode
      * @param Doku_Renderer $R The renderer
@@ -83,7 +83,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         global $ID;
         global $INFO;
         global $REV;
-        if (!($R instanceof Doku_Renderer_xhtml)) {
+        if (!in_array(act_clean($ACT), ['show', 'export_html', 'export_pdf'])) {
             return true;
         }
         if($ID != $INFO['id']) return true;

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -21,6 +21,12 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
     const XHTML_CLOSE = '</div>';
 
     /**
+     * Class names of renderers which should NOT render struct data.
+     * All descendants are also blacklisted.
+     */
+    const BLACKLIST_RENDERER = array('Doku_Renderer_metadata');
+
+    /**
      * @return string Syntax mode type
      */
     public function getType() {
@@ -83,8 +89,11 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         global $ID;
         global $INFO;
         global $REV;
-        if (!in_array(act_clean($ACT), ['show', 'export_html', 'export_pdf'])) {
-            return true;
+
+        foreach (self::BLACKLIST_RENDERER as $blacklisted) {
+            if ($R instanceof $blacklisted) {
+                return true;
+            }
         }
         if($ID != $INFO['id']) return true;
         if(!$INFO['exists']) return true;

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -71,7 +71,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
     /**
      * Render schema data
      *
-     * Currently completely renderer agnostic
+     * No output with renderers other than descendants of Doku_Renderer_xhtml
      *
      * @param string $mode Renderer mode
      * @param Doku_Renderer $R The renderer
@@ -83,7 +83,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
         global $ID;
         global $INFO;
         global $REV;
-        if (!in_array(act_clean($ACT), ['show', 'export_html', 'export_pdf'])) {
+        if (!($R instanceof Doku_Renderer_xhtml)) {
             return true;
         }
         if($ID != $INFO['id']) return true;


### PR DESCRIPTION
fixes #300
related to #424 

It adds `export_pdf` to whitelisted actions in struct's render method. Is this the right approach or a band-aid solution (see #424)?