### PR TITLE
Fix bureaucracy handle lookup fields for Lookup type descendents 

### DIFF
--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -13,6 +13,7 @@ use dokuwiki\plugin\struct\meta\AccessTable;
 use dokuwiki\plugin\struct\meta\Assignments;
 use dokuwiki\plugin\struct\meta\Schema;
 use dokuwiki\plugin\struct\meta\Search;
+use dokuwiki\plugin\struct\types\Lookup;
 
 /**
  * Handles bureaucracy additions
@@ -85,7 +86,7 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin {
     public function handle_lookup_fields(Doku_Event $event, $param) {
         foreach($event->data['fields'] as $field) {
             if(!is_a($field, 'helper_plugin_struct_field')) continue;
-            if($field->column->getType()->getClass() != 'Lookup') continue;
+            if(!$field->column->getType() instanceof Lookup) continue;
 
             $value = $field->getParam('value');
             if (!is_array($value)) $value = array($value);
@@ -140,7 +141,7 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin {
             $lbl = $field->column->getLabel();
             if(!isset($tosave[$tbl])) $tosave[$tbl] = array();
 
-            if ($field->column->isMulti() && $field->column->getType()->getClass() == 'Lookup') {
+            if ($field->column->isMulti() && $field->column->getType() instanceof Lookup) {
                 $tosave[$tbl][$lbl] = $field->opt['struct_pids'];
             } else {
                 $tosave[$tbl][$lbl] = $field->getParam('value');

--- a/helper/field.php
+++ b/helper/field.php
@@ -4,6 +4,7 @@ use dokuwiki\plugin\struct\meta\Schema;
 use dokuwiki\plugin\struct\meta\StructException;
 use dokuwiki\plugin\struct\meta\Value;
 use dokuwiki\plugin\struct\meta\ValueValidator;
+use dokuwiki\plugin\struct\types\Lookup;
 
 /**
  * Allows adding a single struct field as a bureaucracy field
@@ -86,7 +87,7 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
 
         // output the field
         $value = new Value($this->column, $this->opt['value']);
-        if ($this->column->getType()->getClass() == 'Lookup') {
+        if ($this->column->getType() instanceof Lookup) {
             $value->setValue($this->opt['value'], true);
         }
         $field = $this->makeField($value, $params['name']);


### PR DESCRIPTION
Because there are plugins that extends the Lookup type: (ex. [structcombolookup](https://www.dokuwiki.org/plugin:structcombolookup)) we should check if the column is Lookup or one of its descendants.