### PR TITLE
Fix no closing thead in data table

### DIFF
--- a/syntax/output.php
+++ b/syntax/output.php
@@ -131,7 +131,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin {
             $R->cdata($schemadata->getSchema()->getTranslatedLabel());
             $R->tableheader_close();
             $R->tablerow_close();
-            $R->tablethead_open();
+            $R->tablethead_close();
 
             $R->tabletbody_open();
             foreach($data as $field) {


### PR DESCRIPTION
The `thead` in the rendered table is opened twice but never closed.
This fixes that by swapping one open with a close.

(By the way, using a `thead` and a spanning `th` here is semantically incorrect. This should really be a `caption`.)