### PR TITLE
Make field ids more unique

### DIFF
--- a/helper/field.php
+++ b/helper/field.php
@@ -109,7 +109,7 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field {
         $colname = $field->getColumn()->getFullQualifiedLabel();
         $required = $this->opt['optional'] ? '' : ' <sup>*</sup>';
 
-        $id = uniqid('struct__', false);
+        $id = uniqid('struct__', true);
         $input = $field->getValueEditor($name, $id);
 
         $html = '<div class="field">';


### PR DESCRIPTION
On some systems the timestamp-based field ids were not unique. In addition to being invalid HTML,
this broke e.g. date pickers. This PR simply adds the `more_entropy` option, which produces longer ids, more likely to be unique.

This might explain and solve #375