### PR TITLE
fix PHP7.4 deprecation warning

### DIFF
--- a/admin/assignments.php
+++ b/admin/assignments.php
@@ -60,7 +60,7 @@ class admin_plugin_struct_assignments extends DokuWiki_Admin_Plugin {
                     $ok = $assignments->removePattern($assignment['assign'], $assignment['tbl']);
                     if(!$ok) msg('failed to remove pattern', -1);
                 } else if($INPUT->str('action') === 'add') {
-                    if($assignment['assign']{0} == '/') {
+                    if($assignment['assign'][0] == '/') {
                         if(@preg_match($assignment['assign'], null) === false) {
                             msg('Invalid regular expression. Pattern not saved', -1);
                         } else {

--- a/meta/ConfigParser.php
+++ b/meta/ConfigParser.php
@@ -255,14 +255,14 @@ class ConfigParser {
         $value = '';
         $len = strlen($line);
         for($i = 0; $i < $len; $i++) {
-            if($line{$i} == '"') {
+            if($line[$i] == '"') {
                 if($inQuote) {
                     if($escapedQuote) {
                         $value .= '"';
                         $escapedQuote = false;
                         continue;
                     }
-                    if($line{$i + 1} == '"') {
+                    if($line[$i + 1] == '"') {
                         $escapedQuote = true;
                         continue;
                     }
@@ -275,7 +275,7 @@ class ConfigParser {
                     $value = ''; //don't store stuff before the opening quote
                     continue;
                 }
-            } else if($line{$i} == ',') {
+            } else if($line[$i] == ',') {
                 if($inQuote) {
                     $value .= ',';
                     continue;
@@ -288,7 +288,7 @@ class ConfigParser {
                     continue;
                 }
             }
-            $value .= $line{$i};
+            $value .= $line[$i];
         }
         if(strlen($value) > 0) {
             array_push($values, trim($value));


### PR DESCRIPTION
Accessing arrays with curly braces is deprecated in PHP 7.4 and triggers
annoying warnings.