### PR TITLE
Add github workflow for phpcs

### DIFF
--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -1,0 +1,30 @@
+name: PHP Code Style
+
+on: [push]
+
+jobs:
+    phpcs:
+        name: PHP CodeSniffer
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+
+            - name: Setup PHP
+              uses: nanasess/setup-php@master
+              with:
+                  php-version: 7.3
+
+            - name: retrieve script
+              run: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
+
+            - name: Install DokuWiki
+              env:
+                  CI_SERVER: 1
+                  DOKUWIKI : master
+              run: sh travis.sh
+
+            - name: Download PHPCS
+              run: wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+
+            - name: run PHP codesniffer
+              run: php phpcs.phar -v --standard=_test/phpcs.xml lib/plugins/struct


### PR DESCRIPTION
I actually wanted to also let Travis run on PHP 7.4, but that is broken because `travis.sh` downloads PHPUnit 8 for PHP 7.4 and that is pretty hard incompatible with our current codebase and I'm not sure how to work around that.

So currently this runs phpcs with the Dokuwiki ruleset on the struct code base.