### PR TITLE
New event PLUGIN_STRUCT_AGGREGATIONTABLE_RENDERRESULTROW

### DIFF
--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -344,7 +344,20 @@ class AggregationTable {
      */
     protected function renderResult() {
         foreach($this->result as $rownum => $row) {
-            $this->renderResultRow($rownum, $row);
+            $data = array(
+                'id' => $this->id,
+                'mode' => $this->mode,
+                'renderer' => $this->renderer,
+                'searchConfig' => $this->searchConfig,
+                'data' => $this->data,
+                'rownum' => &$rownum,
+                'row' => &$row,
+            );
+            $evt = new \Doku_Event('PLUGIN_STRUCT_AGGREGATIONTABLE_RENDERRESULTROW', $data);
+            if($evt->advise_before()) {
+                $this->renderResultRow($rownum, $row);
+            }
+            $evt->advise_after();
         }
     }
 


### PR DESCRIPTION
This commit adds a new event: "PLUGIN_STRUCT_AGGREGATIONTABLE_RENDERRESULTROW"  to the AggergationTable class. This event allows plugin developers to modify rows rendered by struct table.

I used this event to implement [strudtrowcolor plugin](https://github.com/gkrid/dokuwiki-plugin-structrowcolor). The plugin allows the user to color the table rows by color fields. I also implemented "rowcolor" feature as [a direct struct plugin modification](https://github.com/solewniczak/dokuwiki-plugin-struct/tree/feature-rowcolor) but I believe that the version using the event is better.