### PR TITLE
Do not fail CodeSniffer check on warnings

### DIFF
--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -27,4 +27,4 @@ jobs:
               run: wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
 
             - name: run PHP codesniffer
-              run: php phpcs.phar -v --standard=_test/phpcs.xml lib/plugins/struct
+              run: php phpcs.phar -v --runtime-set ignore_warnings_on_exit true --standard=_test/phpcs.xml lib/plugins/struct

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   struct
 author Andreas Gohr, Michael Große
 email  dokuwiki@cosmocode.de
-date   2020-02-04
+date   2020-03-17
 name   struct plugin
 desc   Add and query additional structured page data
 url    https://www.dokuwiki.org/plugin:struct


### PR DESCRIPTION
This PR makes phpcs check return exit code 0 when there were no errors detected, only warnings