### PR TITLE
refactoring names

### DIFF
--- a/_test/AggregationExportCSV.test.php
+++ b/_test/AggregationExportCSV.test.php
@@ -27,7 +27,7 @@ class AggregationExportCSV extends StructTest
             'SecondFieldLongText' => "abc\ndef\n",
             'ThirdFieldWiki' => "  * hi\n  * ho",
         ];
-        $access = AccessTable::getLookupAccess('wikilookup');
+        $access = AccessTable::getGlobalAccess('wikilookup');
         $helper->saveLookupData($access, $saveDate);
     }
 

--- a/_test/AggregationResults.test.php
+++ b/_test/AggregationResults.test.php
@@ -5,9 +5,9 @@ namespace dokuwiki\plugin\struct\test;
 use dokuwiki\plugin\struct\meta\ConfigParser;
 use dokuwiki\plugin\struct\meta\PageMeta;
 use dokuwiki\plugin\struct\test\mock\AccessTable;
-use dokuwiki\plugin\struct\test\mock\AccessTableData;
+use dokuwiki\plugin\struct\test\mock\AccessTablePage;
 use dokuwiki\plugin\struct\test\mock\AggregationTable;
-use dokuwiki\plugin\struct\test\mock\LookupTable;
+use dokuwiki\plugin\struct\test\mock\AggregationEditorTable;
 use dokuwiki\plugin\struct\test\mock\SearchConfig;
 
 /**
@@ -159,17 +159,17 @@ class AggregationResults_struct_test extends StructTest
 
         // FIXME simulate addYypeFilter() from \syntax_plugin_struct_serial or \syntax_plugin_struct_lookup
         if ($id) {
-            $config['filter'][] = ['%rowid%', '!=', (string)AccessTableData::DEFAULT_PAGE_RID, 'AND'];
+            $config['filter'][] = ['%rowid%', '!=', (string)AccessTablePage::DEFAULT_PAGE_RID, 'AND'];
             $config['filter'][] = ['%pageid%', '=', $id, 'AND'];
         } else {
-            $config['filter'][] = ['%rowid%', '!=', (string)\dokuwiki\plugin\struct\meta\AccessTableData::DEFAULT_PAGE_RID, 'AND'];
+            $config['filter'][] = ['%rowid%', '!=', (string)\dokuwiki\plugin\struct\meta\AccessTablePage::DEFAULT_PAGE_RID, 'AND'];
             $config['filter'][] = ['%pageid%', '=*', '^(?![\s\S])', 'AND'];
         }
 
         if ($filters) array_push($config['filter'], $filters);
         $search = new SearchConfig($config);
 
-        $table = new LookupTable($id, 'xhtml', new \Doku_Renderer_xhtml(), $search);
+        $table = new AggregationEditorTable($id, 'xhtml', new \Doku_Renderer_xhtml(), $search);
         return $table->getResult();
     }
 
@@ -188,7 +188,7 @@ class AggregationResults_struct_test extends StructTest
         $pageMeta->setTitle('Another Title');
 
         $this->loadSchemaJSON('pageschema');
-        $access = AccessTable::getLookupAccess('pageschema');
+        $access = AccessTable::getGlobalAccess('pageschema');
         $access->saveData(
             array(
                 'singlepage' => 'title1',
@@ -197,7 +197,7 @@ class AggregationResults_struct_test extends StructTest
                 'multititle' => array('title1'),
             )
         );
-        $access = AccessTable::getLookupAccess('pageschema');
+        $access = AccessTable::getGlobalAccess('pageschema');
         $access->saveData(
             array(
                 'singlepage' => 'title2',
@@ -206,7 +206,7 @@ class AggregationResults_struct_test extends StructTest
                 'multititle' => array('title2'),
             )
         );
-        $access = AccessTable::getLookupAccess('pageschema');
+        $access = AccessTable::getGlobalAccess('pageschema');
         $access->saveData(
             array(
                 'singlepage' => 'title3',

--- a/_test/Bureaucracy.test.php
+++ b/_test/Bureaucracy.test.php
@@ -34,7 +34,7 @@ class Bureaucracy_struct_test extends StructTest {
                 'lookup_second' => 'value second ' . $i
             );
 
-            $lookupData = AccessTable::getLookupAccess('bureaucracy_lookup');
+            $lookupData = AccessTable::getGlobalAccess('bureaucracy_lookup');
             $lookupData->saveData($data);
             $this->lookup[] = $lookupData;
         }

--- a/_test/StructTest.php
+++ b/_test/StructTest.php
@@ -3,7 +3,7 @@
 namespace dokuwiki\plugin\struct\test;
 
 use dokuwiki\plugin\struct\meta\AccessTable;
-use dokuwiki\plugin\struct\test\mock\AccessTableData;
+use dokuwiki\plugin\struct\test\mock\AccessTablePage;
 use dokuwiki\plugin\struct\test\mock\Assignments;
 use dokuwiki\plugin\struct\meta\SchemaImporter;
 
@@ -100,7 +100,7 @@ abstract class StructTest extends \DokuWikiTest {
         } elseif(AccessTable::isTypeSerial($page, $rev)) {
             $access = AccessTable::getSerialAccess($table, $page);
         } else {
-            $access = AccessTable::getLookupAccess($table, $page);
+            $access = AccessTable::getGlobalAccess($table, $page);
         }
         $access->saveData($data);
         $assignments = Assignments::getInstance();

--- a/_test/Type_Lookup.test.php
+++ b/_test/Type_Lookup.test.php
@@ -28,7 +28,7 @@ class Type_Lookup_struct_test extends StructTest {
         $pageMeta->setTitle('Another Title');
 
         $this->loadSchemaJSON('pageschema', '', 0);
-        $access = AccessTable::getLookupAccess('pageschema');
+        $access = AccessTable::getGlobalAccess('pageschema');
         $access->saveData(
             array(
                 'singlepage' => 'title1',
@@ -37,7 +37,7 @@ class Type_Lookup_struct_test extends StructTest {
                 'multititle' => array('title1'),
             )
         );
-        $access = AccessTable::getLookupAccess('pageschema');
+        $access = AccessTable::getGlobalAccess('pageschema');
         $access->saveData(
             array(
                 'singlepage' => 'title2',
@@ -46,7 +46,7 @@ class Type_Lookup_struct_test extends StructTest {
                 'multititle' => array('title2'),
             )
         );
-        $access = AccessTable::getLookupAccess('pageschema');
+        $access = AccessTable::getGlobalAccess('pageschema');
         $access->saveData(
             array(
                 'singlepage' => 'title3',
@@ -59,7 +59,7 @@ class Type_Lookup_struct_test extends StructTest {
 
     protected function prepareTranslation() {
         $this->loadSchemaJSON('translation', '', 0);
-        $access = AccessTable::getLookupAccess('translation');
+        $access = AccessTable::getGlobalAccess('translation');
         $access->saveData(
             array(
                 'en' => 'shoe',
@@ -68,7 +68,7 @@ class Type_Lookup_struct_test extends StructTest {
             )
         );
 
-        $access = AccessTable::getLookupAccess('translation');
+        $access = AccessTable::getGlobalAccess('translation');
         $access->saveData(
             array(
                 'en' => 'dog',
@@ -77,7 +77,7 @@ class Type_Lookup_struct_test extends StructTest {
             )
         );
 
-        $access = AccessTable::getLookupAccess('translation');
+        $access = AccessTable::getGlobalAccess('translation');
         $access->saveData(
             array(
                 'en' => 'cat',

--- a/_test/action/LookupAjaxAction..php
+++ b/_test/action/LookupAjaxAction..php
@@ -6,7 +6,7 @@ use dokuwiki\plugin\struct\meta\AccessTable;
 use dokuwiki\plugin\struct\test\StructTest;
 
 /**
- * @covers action_plugin_struct_lookup
+ * @covers action_plugin_struct_aggregationeditor
  *
  * @group plugin_struct
  * @group plugins
@@ -28,11 +28,11 @@ class LookupAjaxAction extends StructTest
             'SecondFieldLongText' => "abc\ndef\n",
             'ThirdFieldWiki' => "  * hi\n  * ho",
         ];
-        $access = AccessTable::getLookupAccess('wikilookup');
+        $access = AccessTable::getGlobalAccess('wikilookup');
         $helper->saveLookupData($access, $saveDate);
     }
 
-    public function testSaveLookupDataEvent()
+    public function testSaveGlobalDataEvent()
     {
         $testLabel = 'testcontent';
         global $INPUT;
@@ -42,7 +42,7 @@ class LookupAjaxAction extends StructTest
             'schemas' => [['wikilookup', '']],
             'cols' => ['*']
         ]));
-        $call = 'plugin_struct_lookup_save';
+        $call = 'plugin_struct_aggregationeditor_save';
         $evt = new \Doku_Event('AJAX_CALL_UNKNOWN', $call);
 
         $this->expectOutputRegex('/\s*<tr.*' . $testLabel . '.*<\/td>\s*/');

--- a/_test/mock/AccessTable.php
+++ b/_test/mock/AccessTable.php
@@ -3,7 +3,7 @@
 namespace dokuwiki\plugin\struct\test\mock;
 
 use dokuwiki\plugin\struct\meta;
-use dokuwiki\plugin\struct\meta\AccessTableLookup;
+use dokuwiki\plugin\struct\meta\AccessTableGlobal;
 use dokuwiki\plugin\struct\meta\Schema;
 
 abstract class AccessTable extends meta\AccessTable {
@@ -11,31 +11,31 @@ abstract class AccessTable extends meta\AccessTable {
     public static function getPageAccess($tablename, $pid, $ts = 0)
     {
         $schema = new Schema($tablename, $ts);
-        return new AccessTableData($schema, $pid, $ts, 0);
+        return new AccessTablePage($schema, $pid, $ts, 0);
     }
 
     /**
-     * @deprecated
      * @param Schema $schema
      * @param int|string $pid
      * @param int $ts
      * @param int $rid
-     * @return AccessTableLookup|AccessTableData
+     * @return AccessTableGlobal|AccessTablePage
+     *@deprecated
      */
     public static function bySchema(Schema $schema, $pid, $ts = 0, $rid = 0) {
         if (self::isTypePage($pid, $ts, $rid)) {
-            return new AccessTableData($schema, $pid, $ts, $rid);
+            return new AccessTablePage($schema, $pid, $ts, $rid);
         }
-        return new AccessTableLookup($schema, $pid, $ts, $rid);
+        return new AccessTableGlobal($schema, $pid, $ts, $rid);
     }
 
     /**
-     * @deprecated
      * @param string $tablename
      * @param string $pid
      * @param int $ts
      * @param int $rid
-     * @return meta\AccessTableData|AccessTableLookup|AccessTableData
+     * @return meta\AccessTablePage|AccessTableGlobal|AccessTablePage
+     *@deprecated
      */
     public static function byTableName($tablename, $pid, $ts = 0, $rid = 0) {
         $schema = new Schema($tablename, $ts);

--- a/_test/mock/AccessTableDataNoDB.php
+++ b/_test/mock/AccessTableDataNoDB.php
@@ -5,7 +5,7 @@ namespace dokuwiki\plugin\struct\test\mock;
 use dokuwiki\plugin\struct\meta\Column;
 
 
-class AccessTableDataNoDB extends AccessTableData {
+class AccessTableDataNoDB extends AccessTablePage {
 
 
     /** @noinspection PhpMissingParentConstructorInspection

--- a/_test/mock/AccessTablePage.php
+++ b/_test/mock/AccessTablePage.php
@@ -2,7 +2,7 @@
 
 namespace dokuwiki\plugin\struct\test\mock;
 
-class AccessTableData extends \dokuwiki\plugin\struct\meta\AccessTableData {
+class AccessTablePage extends \dokuwiki\plugin\struct\meta\AccessTablePage {
 
     public function getDataFromDB() {
         return parent::getDataFromDB();

--- a/_test/mock/AggregationEditorTable.php
+++ b/_test/mock/AggregationEditorTable.php
@@ -4,7 +4,7 @@ namespace dokuwiki\plugin\struct\test\mock;
 
 use dokuwiki\plugin\struct\meta;
 
-class LookupTable extends meta\LookupTable {
+class AggregationEditorTable extends meta\AggregationEditorTable {
     public function getResult()
     {
         return $this->result;

--- a/action/diff.php
+++ b/action/diff.php
@@ -9,7 +9,7 @@
 
 use dokuwiki\plugin\struct\meta\AccessTable;
 use dokuwiki\plugin\struct\meta\Assignments;
-use dokuwiki\plugin\struct\meta\AccessTableData;
+use dokuwiki\plugin\struct\meta\AccessTablePage;
 use dokuwiki\plugin\struct\meta\StructException;
 
 class action_plugin_struct_diff extends DokuWiki_Action_Plugin

--- a/action/inline.php
+++ b/action/inline.php
@@ -8,8 +8,8 @@
  */
 
 use dokuwiki\plugin\struct\meta\AccessTable;
-use dokuwiki\plugin\struct\meta\AccessTableData;
-use dokuwiki\plugin\struct\meta\AccessTableLookup;
+use dokuwiki\plugin\struct\meta\AccessTablePage;
+use dokuwiki\plugin\struct\meta\AccessTableGlobal;
 use dokuwiki\plugin\struct\meta\Assignments;
 use dokuwiki\plugin\struct\meta\Column;
 use dokuwiki\plugin\struct\meta\Schema;
@@ -24,7 +24,7 @@ use dokuwiki\plugin\struct\meta\ValueValidator;
 class action_plugin_struct_inline extends DokuWiki_Action_Plugin
 {
 
-    /** @var  AccessTableData */
+    /** @var  AccessTablePage */
     protected $schemadata = null;
 
     /** @var  Column */
@@ -224,7 +224,7 @@ class action_plugin_struct_inline extends DokuWiki_Action_Plugin
             } elseif (AccessTable::isTypeSerial($pid, $rev)) {
                 $this->schemadata = AccessTable::getSerialAccess($table, $pid, $rid);
             } else {
-                $this->schemadata = AccessTable::getLookupAccess($table, $rid);
+                $this->schemadata = AccessTable::getGlobalAccess($table, $rid);
             }
         } catch (StructException $ignore) {
             return false;

--- a/deleted.files
+++ b/deleted.files
@@ -1,3 +1,11 @@
 _test/Type_Integer.test.php
 types/Integer.php
 meta/Page.php
+_test/mock/AccessTableData.php
+_test/mock/LookupTable.php
+meta/AccessTableLookup.php
+meta/AccessTableData.php
+meta/LookupTable.php
+script/LookupEditor.js
+action/lookup.php
+syntax/lookup.php

--- a/helper.php
+++ b/helper.php
@@ -10,7 +10,7 @@
 // must be run within Dokuwiki
 use dokuwiki\plugin\struct\meta\AccessDataValidator;
 use dokuwiki\plugin\struct\meta\AccessTable;
-use dokuwiki\plugin\struct\meta\AccessTableLookup;
+use dokuwiki\plugin\struct\meta\AccessTableGlobal;
 use dokuwiki\plugin\struct\meta\Assignments;
 use dokuwiki\plugin\struct\meta\Schema;
 use dokuwiki\plugin\struct\meta\StructException;

--- a/helper/lookup.php
+++ b/helper/lookup.php
@@ -1,7 +1,7 @@
 <?php
 
 use dokuwiki\plugin\struct\meta\AccessTable;
-use dokuwiki\plugin\struct\meta\AccessTableLookup;
+use dokuwiki\plugin\struct\meta\AccessTableGlobal;
 use dokuwiki\plugin\struct\meta\StructException;
 
 /**
@@ -37,8 +37,8 @@ class helper_plugin_struct_lookup extends helper_plugin_bureaucracy_action
         }
 
         foreach ($tosave as $table => $data) {
-            $access = AccessTable::getLookupAccess($table);
-            if (!$access instanceof AccessTableLookup) continue;
+            $access = AccessTable::getGlobalAccess($table);
+            if (!$access instanceof AccessTableGlobal) continue;
 
             if (!$access->getSchema()->isEditable()) {
                 msg('lookup save error: no permission for schema', -1);

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -55,7 +55,7 @@ abstract class AccessTable
     public static function getPageAccess($tablename, $pid, $ts = 0)
     {
         $schema = new Schema($tablename, $ts);
-        return new AccessTableData($schema, $pid, $ts, 0);
+        return new AccessTablePage($schema, $pid, $ts, 0);
     }
 
     public static function getSerialAccess($tablename, $pid, $rid = 0)
@@ -64,40 +64,40 @@ abstract class AccessTable
         return new AccessTableSerial($schema, $pid, 0, $rid);
     }
 
-    public static function getLookupAccess($tablename, $rid = 0)
+    public static function getGlobalAccess($tablename, $rid = 0)
     {
         $schema = new Schema($tablename, 0);
-        return new AccessTableLookup($schema, '', 0, $rid);
+        return new AccessTableGlobal($schema, '', 0, $rid);
     }
 
     /**
-     * Factory method returning the appropriate data accessor (page, lookup or serial)
+     * Factory method returning the appropriate data accessor (page, global or serial)
      *
-     * @deprecated
      * @param Schema $schema schema to load
      * @param string $pid Page id to access
      * @param int $ts Time at which the data should be read or written
      * @param int $rid Row id, 0 for page type data, otherwise autoincrement
-     * @return AccessTableData|AccessTableLookup
+     * @return AccessTablePage|AccessTableGlobal
+     * @deprecated
      */
     public static function bySchema(Schema $schema, $pid, $ts = 0, $rid = 0)
     {
         if (self::isTypePage($pid, $ts)) {
-            return new AccessTableData($schema, $pid, $ts, $rid);
+            return new AccessTablePage($schema, $pid, $ts, $rid);
         }
-        return new AccessTableLookup($schema, $pid, $ts, $rid);
+        return new AccessTableGlobal($schema, $pid, $ts, $rid);
     }
 
     /**
      * Factory Method to access data
      *
-     * @deprecated  Use specific methods since we can no longer
-     *              guarantee instantiating the required descendant class
      * @param string $tablename schema to load
      * @param string $pid Page id to access
      * @param int $ts Time at which the data should be read or written
      * @param int $rid Row id, 0 for page type data, otherwise autoincrement
-     * @return AccessTableData|AccessTableLookup
+     * @return AccessTablePage|AccessTableGlobal
+     *@deprecated  Use specific methods since we can no longer
+     *              guarantee instantiating the required descendant class
      */
     public static function byTableName($tablename, $pid, $ts = 0, $rid = 0)
     {
@@ -557,14 +557,14 @@ abstract class AccessTable
     }
 
     /**
-     * Returns true if data is of type "lookup"
+     * Returns true if data is of type "global"
      *
      * @param string $pid
      * @param int $rev
      * @param int $rid
      * @return bool
      */
-    public static function isTypeLookup($pid, $rev)
+    public static function isTypeGlobal($pid, $rev)
     {
         return $pid === '';
     }

--- a/meta/AccessTableGlobal.php
+++ b/meta/AccessTableGlobal.php
@@ -3,13 +3,13 @@
 namespace dokuwiki\plugin\struct\meta;
 
 /**
- * Class AccessTableLookup
+ * Class AccessTableGlobal
  *
- * Load and (more importantly) save data for Lookup Schemas
+ * Load and (more importantly) save data for Global Schemas
  *
  * @package dokuwiki\plugin\struct\meta
  */
-class AccessTableLookup extends AccessTable
+class AccessTableGlobal extends AccessTable
 {
     public function __construct($table, $pid, $ts = 0, $rid = 0)
     {

--- a/meta/AccessTablePage.php
+++ b/meta/AccessTablePage.php
@@ -9,7 +9,7 @@ namespace dokuwiki\plugin\struct\meta;
  * This class is for accessing the data stored for a page in a schema
  *
  */
-class AccessTableData extends AccessTable
+class AccessTablePage extends AccessTable
 {
 
     const DEFAULT_PAGE_RID = 0;

--- a/meta/AccessTableSerial.php
+++ b/meta/AccessTableSerial.php
@@ -9,7 +9,7 @@ namespace dokuwiki\plugin\struct\meta;
  *
  * @package dokuwiki\plugin\struct\meta
  */
-class AccessTableSerial extends AccessTableLookup
+class AccessTableSerial extends AccessTableGlobal
 {
     public function __construct($table, $pid, $ts = 0, $rid = 0)
     {

--- a/meta/AggregationEditorTable.php
+++ b/meta/AggregationEditorTable.php
@@ -3,13 +3,13 @@
 namespace dokuwiki\plugin\struct\meta;
 
 /**
- * Class LookupTable
+ * Class AggregationEditorTable
  *
- * An AggregationTable for editing lookup tables
+ * An AggregationTable for editing global and serial tables
  *
  * @package dokuwiki\plugin\struct\meta
  */
-class LookupTable extends AggregationTable
+class AggregationEditorTable extends AggregationTable
 {
 
     /**
@@ -38,7 +38,7 @@ class LookupTable extends AggregationTable
         $config = hsc(json_encode($config));
 
         // wrapping div
-        $this->renderer->doc .= "<div class=\"structaggregation structlookup\" data-schema=\"$table\" data-searchconf=\"$config\">";
+        $this->renderer->doc .= "<div class=\"structaggregation structaggregationeditor\" data-schema=\"$table\" data-searchconf=\"$config\">";
 
         // unique identifier for this aggregation
         $this->renderer->info['struct_table_hash'] = md5(var_export($this->data, true));

--- a/meta/Assignments.php
+++ b/meta/Assignments.php
@@ -20,9 +20,6 @@ class Assignments
     /** @var  array All the assignments patterns */
     protected $patterns;
 
-    /** @var  string[] All lookup schemas for error checking */
-    protected $lookups;
-
     /** @var Assignments */
     protected static $instance = null;
 

--- a/meta/CSVExporter.php
+++ b/meta/CSVExporter.php
@@ -5,8 +5,7 @@ namespace dokuwiki\plugin\struct\meta;
 /**
  * Class CSVExporter
  *
- * exports raw schema data to CSV. For lookup schemas this data can be reimported again through
- * CSVImporter
+ * exports raw schema data to CSV.
  *
  * Note this is different from syntax/csv.php
  *
@@ -15,7 +14,7 @@ namespace dokuwiki\plugin\struct\meta;
 class CSVExporter
 {
     const DATATYPE_PAGE = 'page';
-    const DATATYPE_LOOKUP = 'lookup';
+    const DATATYPE_GLOBAL = 'global';
     const DATATYPE_SERIAL = 'serial';
 
     protected $type = '';
@@ -36,13 +35,13 @@ class CSVExporter
         $search->addColumn('*');
         $result = $search->execute();
 
-        if ($this->type !== self::DATATYPE_LOOKUP) {
+        if ($this->type !== self::DATATYPE_GLOBAL) {
             $pids = $search->getPids();
         }
 
         echo $this->header($search->getColumns());
         foreach ($result as $i => $row) {
-            if ($this->type !== self::DATATYPE_LOOKUP) {
+            if ($this->type !== self::DATATYPE_GLOBAL) {
                 $pid = $pids[$i];
             } else {
                 $pid = '';
@@ -61,7 +60,7 @@ class CSVExporter
     {
         $row = '';
 
-        if ($this->type !== self::DATATYPE_LOOKUP) {
+        if ($this->type !== self::DATATYPE_GLOBAL) {
             $row .= $this->escape('pid');
             $row .= ',';
         }
@@ -83,7 +82,7 @@ class CSVExporter
     protected function row($values, $pid)
     {
         $row = '';
-        if ($this->type !== self::DATATYPE_LOOKUP) {
+        if ($this->type !== self::DATATYPE_GLOBAL) {
             $row .= $this->escape($pid);
             $row .= ',';
         }

--- a/meta/CSVImporter.php
+++ b/meta/CSVImporter.php
@@ -7,7 +7,7 @@ use dokuwiki\plugin\struct\types\Page;
 /**
  * Class CSVImporter
  *
- * Imports CSV data into a lookup schema
+ * Imports CSV data
  *
  * @package dokuwiki\plugin\struct\meta
  */
@@ -36,7 +36,7 @@ class CSVImporter
     protected $errors;
 
     /**
-     * @var string data type, must be one of page, lookup, serial
+     * @var string data type, must be one of page, global, serial
      */
     protected $type;
 
@@ -111,7 +111,7 @@ class CSVImporter
         $this->line++;
 
         // we might have to create a page column first
-        if ($this->type !== CSVExporter::DATATYPE_LOOKUP) {
+        if ($this->type !== CSVExporter::DATATYPE_GLOBAL) {
             $pageType = new Page(null, 'pid');
             $pidCol = new Column(0, $pageType, 0, true, $this->schema->getTable());
             $this->columns[] = $pidCol;
@@ -223,7 +223,7 @@ class CSVImporter
         if ($this->type === CSVExporter::DATATYPE_SERIAL) {
             $access = AccessTable::getSerialAccess($table, $pid);
         } else {
-            $access = AccessTable::getLookupAccess($table);
+            $access = AccessTable::getGlobalAccess($table);
         }
         $helper->saveLookupData($access, $data);
     }

--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ jQuery(function() {
     function init() {
         EntryEditor(jQuery('#dw__editform, form.bureaucracy__plugin'));
         SchemaEditor();
-        jQuery('div.structlookup table').each(LookupEditor);
+        jQuery('div.structaggregationeditor table').each(AggregationEditor);
         InlineEditor(jQuery('div.structaggregation table'));
     }
 

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ jQuery(function() {
     /* DOKUWIKI:include script/functions.js */
     /* DOKUWIKI:include script/EntryEditor.js */
     /* DOKUWIKI:include script/SchemaEditor.js */
-    /* DOKUWIKI:include script/LookupEditor.js */
+    /* DOKUWIKI:include script/AggregationEditor.js */
     /* DOKUWIKI:include script/InlineEditor.js */
 
     function init() {

--- a/script/AggregationEditor.js
+++ b/script/AggregationEditor.js
@@ -1,7 +1,7 @@
 /**
  * Lookup Editor
  */
-var LookupEditor = function (idx, table) {
+var AggregationEditor = function (idx, table) {
     var $table = jQuery(table);
     var $form = null;
     var formdata;
@@ -43,10 +43,10 @@ var LookupEditor = function (idx, table) {
                     jQuery.post(
                         DOKU_BASE + 'lib/exe/ajax.php',
                         {
-                            call: 'plugin_struct_lookup_delete',
+                            call: 'plugin_struct_aggregationeditor_delete',
                             schema: schema,
                             rid: rid,
-                            sectok: $me.parents('.structlookup').find('.struct_entry_form input[name=sectok]').val()
+                            sectok: $me.parents('.structaggregationeditor').find('.struct_entry_form input[name=sectok]').val()
                         }
                     )
                         .done(function () {
@@ -130,7 +130,7 @@ var LookupEditor = function (idx, table) {
     jQuery.post(
         DOKU_BASE + 'lib/exe/ajax.php',
         {
-            call: 'plugin_struct_lookup_new',
+            call: 'plugin_struct_aggregationeditor_new',
             schema: schema
         },
         function (data) {

--- a/style.less
+++ b/style.less
@@ -375,7 +375,7 @@ form.struct_newschema {
 /**
  * Lookup Aggregation Editor
  */
-.dokuwiki .structlookup {
+.dokuwiki .structaggregationeditor {
     table.inline {
         min-width: 100%;
 
@@ -420,7 +420,7 @@ form.struct_newschema {
 /**
  * Errors on AJAX
  */
-.dokuwiki .structlookup form,
+.dokuwiki .structaggregationeditor form,
 .dokuwiki .struct_inlineditor {
     .err {
         font-size: 90%;

--- a/syntax/global.php
+++ b/syntax/global.php
@@ -7,16 +7,16 @@
  * @author  Andreas Gohr, Michael Große <dokuwiki@cosmocode.de>
  */
 
-use dokuwiki\plugin\struct\meta\LookupTable;
+use dokuwiki\plugin\struct\meta\AggregationEditorTable;
 
 // must be run within Dokuwiki
 if (!defined('DOKU_INC')) die();
 
-class syntax_plugin_struct_lookup extends syntax_plugin_struct_table
+class syntax_plugin_struct_global extends syntax_plugin_struct_table
 {
 
     /** @var string which class to use for output */
-    protected $tableclass = LookupTable::class;
+    protected $tableclass = AggregationEditorTable::class;
 
     /**
      * Connect lookup pattern to lexer.
@@ -25,7 +25,10 @@ class syntax_plugin_struct_lookup extends syntax_plugin_struct_table
      */
     public function connectTo($mode)
     {
-        $this->Lexer->addSpecialPattern('----+ *struct lookup *-+\n.*?\n----+', $mode, 'plugin_struct_lookup');
+        $this->Lexer->addSpecialPattern('----+ *struct global *-+\n.*?\n----+', $mode, 'plugin_struct_global');
+
+        // deprecated:
+        $this->Lexer->addSpecialPattern('----+ *struct lookup *-+\n.*?\n----+', $mode, 'plugin_struct_global');
     }
 
     /**
@@ -59,7 +62,7 @@ class syntax_plugin_struct_lookup extends syntax_plugin_struct_table
      */
     protected function addTypeFilter($config)
     {
-        $config['filter'][] = ['%rowid%', '!=', (string)\dokuwiki\plugin\struct\meta\AccessTableData::DEFAULT_PAGE_RID, 'AND'];
+        $config['filter'][] = ['%rowid%', '!=', (string)\dokuwiki\plugin\struct\meta\AccessTablePage::DEFAULT_PAGE_RID, 'AND'];
         $config['filter'][] = ['%pageid%', '=*', '^(?![\s\S])', 'AND'];
         $config['withpid'] = 0; // flag for the editor to distinguish data types
         return $config;

--- a/syntax/serial.php
+++ b/syntax/serial.php
@@ -7,9 +7,9 @@
  * @author  Andreas Gohr, Michael Große, Anna Dabrowska <dokuwiki@cosmocode.de>
  */
 
-use dokuwiki\plugin\struct\meta\AccessTableData;
+use dokuwiki\plugin\struct\meta\AccessTablePage;
 
-class syntax_plugin_struct_serial extends syntax_plugin_struct_lookup
+class syntax_plugin_struct_serial extends syntax_plugin_struct_global
 {
 
     /**
@@ -31,7 +31,7 @@ class syntax_plugin_struct_serial extends syntax_plugin_struct_lookup
     protected function addTypeFilter($config)
     {
         global $ID;
-        $config['filter'][] = ['%rowid%', '!=', (string)AccessTableData::DEFAULT_PAGE_RID, 'AND'];
+        $config['filter'][] = ['%rowid%', '!=', (string)AccessTablePage::DEFAULT_PAGE_RID, 'AND'];
         $config['filter'][] = ['%pageid%', '=', $ID, 'AND'];
         $config['withpid'] = 1; // flag for the editor to distinguish data types
         return $config;


### PR DESCRIPTION
To avoid confusion with the Lookup type, the three different ways of accessing a schema have now the following names:

* page data - for revisioned struct data attached to a page
* serial data - for an unrevisioned list of struct data attached to a page
* global data - for an unrevisioned list of struct data not attached to any page (formaly known as lookup schema)

The editor mechanism used for serial and global data is now called AggregationEditor

Some reference to lookup schemas is still in the bureaucracy support part.

@annda can you install this in your test wiki and give it a quick glance? Especially if all the Ajax editing for global and serials still works?