### PR TITLE
Fix migration for structcombolookup plugin

### DIFF
--- a/action/migration.php
+++ b/action/migration.php
@@ -157,7 +157,7 @@ class action_plugin_struct_migration extends DokuWiki_Action_Plugin
                 LEFT OUTER JOIN types AS T
                     ON C.tid = T.id
                 WHERE C.sid = $sid
-                AND TYPE = 'Lookup'
+                AND TYPE LIKE '%Lookup'
             ";
             $res = $sqlite->query($s);
             $cols = $sqlite->res2arr($res);


### PR DESCRIPTION
This simple change fixes the migration for all wikis that use [structcombolookup](https://www.dokuwiki.org/plugin:structcombolookup) plugin. 