### PR TITLE
Bureaucracy: handle both types of lookups

### DIFF
--- a/_test/Bureaucracy.test.php
+++ b/_test/Bureaucracy.test.php
@@ -3,7 +3,6 @@
 namespace dokuwiki\plugin\struct\test;
 
 use dokuwiki\plugin\bureaucracy\test\BureaucracyTest;
-use dokuwiki\plugin\struct\meta;
 use dokuwiki\plugin\struct\meta\AccessTable;
 
 /**
@@ -55,7 +54,7 @@ class Bureaucracy_struct_test extends StructTest {
         $lookup_field = plugin_load('helper', 'struct_field');
         $lookup_field->opt['label'] = 'bureaucracy.lookup_select';
         //empty lookup value
-        $lookup_field->opt['value'] = '["",""]';
+        $lookup_field->opt['value'] = '';
         //left pagename undefined
         //$lookup_field->opt['pagename'];
 
@@ -77,8 +76,8 @@ class Bureaucracy_struct_test extends StructTest {
         $id = 'bureaucracy_lookup_replacement';
         //id of template page
         $template_id = 'template';
-        //pid of selected value
-        $lookup_pid = $this->lookup[0]->getPid();
+        //rid of selected value
+        $lookup_rid = $this->lookup[0]->getRid();
         //selected value
         $lookup_value = $this->lookup[0]->getData()['lookup_first']->getValue();
 
@@ -90,7 +89,7 @@ class Bureaucracy_struct_test extends StructTest {
 
         $lookup_field = plugin_load('helper', 'struct_field');
         $lookup_field->opt['label'] = 'bureaucracy.lookup_select';
-        $lookup_field->opt['value'] = $lookup_pid;
+        $lookup_field->opt['value'] = json_encode(['', $lookup_rid]);
         //left pagename undefined
         //$lookup_field->opt['pagename'];
 

--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -102,12 +102,16 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin
             $search->addColumn($config['field']);
             $result = $search->execute();
             $pids = $search->getPids();
+            $rids = $search->getRids();
 
             $field->opt['struct_pids'] = array();
             $new_value = array();
             foreach ($value as $pid) {
                 for ($i = 0; $i < count($result); $i++) {
-                    if ($pids[$i] == $pid) {
+                    // lookups can reference pages or global data, so check both pid and rid
+                    $pid = json_decode($pid)[0] ?: $pid;
+                    $rid = json_decode($pid)[1];
+                    if ( ($pid && $pids[$i] === $pid) || ($rid && $rids[$i] === (string)$rid) ) {
                         $field->opt['struct_pids'][] = $pid;
                         $new_value[] = $result[$i][0]->getDisplayValue();
                     }

--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -111,7 +111,7 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin
                     // lookups can reference pages or global data, so check both pid and rid
                     $pid = json_decode($pid)[0] ?: $pid;
                     $rid = json_decode($pid)[1];
-                    if ( ($pid && $pids[$i] === $pid) || ($rid && $rids[$i] === (string)$rid) ) {
+                    if (($pid && $pids[$i] === $pid) || ($rid && $rids[$i] === (string)$rid)) {
                         $field->opt['struct_pids'][] = $pid;
                         $new_value[] = $result[$i][0]->getDisplayValue();
                     }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   struct
 author Andreas Gohr, Michael Große
 email  dokuwiki@cosmocode.de
-date   2020-05-20
+date   2020-06-30
 name   struct plugin
 desc   Add and query additional structured page data
 url    https://www.dokuwiki.org/plugin:struct


### PR DESCRIPTION
Placeholders for lookups referencing global data were not replaced properly

fixes #483 