### PR TITLE
Allow deleting all values from a multi field in inline editor

### DIFF
--- a/_test/AccessTableDataDBMulti.test.php
+++ b/_test/AccessTableDataDBMulti.test.php
@@ -60,6 +60,18 @@ class AccessTableDataDBMulti_struct_test extends StructTest {
             ),
             789
         );
+
+        // global data
+        $this->saveData(
+            '',
+            'testtable',
+            [
+                'testMulitColumn2' => ['value1.1b', 'value1.2b'],
+                'testMulitColumn' => ['value2.1b', 'value2.2b']
+            ],
+            0,
+            1
+        );
     }
 
     public function test_getDataFromDB_currentRev() {
@@ -77,5 +89,59 @@ class AccessTableDataDBMulti_struct_test extends StructTest {
         );
 
         $this->assertEquals($expected_data, $actual_data, '');
+    }
+
+    public function test_getDataFromDB_deleteMultiPage() {
+
+        $this->saveData(
+            'testpage',
+            'testtable',
+            [
+                'testMulitColumn2' => '',
+                'testMulitColumn' => ['value2.1a'],
+            ]
+        );
+
+        $expected = [
+            [
+                'out1' => 'value1.1a' . Search::CONCAT_SEPARATOR . 'value1.2a',
+                'out2' => 'value2.1a' . Search::CONCAT_SEPARATOR . 'value2.2a',
+                'PID' => 'testpage',
+            ],
+        ];
+
+        $access = mock\AccessTable::getPageAccess('testtable', 'testpage');
+        $actual = $access->getDataFromDB();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_getDataFromDB_deleteMultiGlobal()
+    {
+
+        $this->saveData(
+            '',
+            'testtable',
+            [
+                'testMulitColumn2' => ['value1.1c', 'value1.2c'],
+                'testMulitColumn' => ['']
+            ],
+            0,
+            1
+        );
+
+        $expected = [
+            [
+                'out1' => 'value1.1c' . Search::CONCAT_SEPARATOR . 'value1.2c',
+                'out2' => '',
+                'RID' => '1',
+            ],
+        ];
+
+        $access = mock\AccessTable::getGlobalAccess('testtable', 1);
+        $actual = $access->getDataFromDB();
+
+        $this->assertEquals($expected, $actual);
+
     }
 }

--- a/_test/StructTest.php
+++ b/_test/StructTest.php
@@ -92,15 +92,16 @@ abstract class StructTest extends \DokuWikiTest {
      * @param string $table
      * @param array $data
      * @param int $rev allows to override the revision timestamp
+     * @param int $rid
      */
-    protected function saveData($page, $table, $data, $rev = 0) {
+    protected function saveData($page, $table, $data, $rev = 0, $rid = 0) {
         saveWikiText($page, "test for $page", "saved for testing");
         if (AccessTable::isTypePage($page, $rev)) {
             $access = AccessTable::getPageAccess($table, $page, $rev);
         } elseif(AccessTable::isTypeSerial($page, $rev)) {
             $access = AccessTable::getSerialAccess($table, $page);
         } else {
-            $access = AccessTable::getGlobalAccess($table, $page);
+            $access = AccessTable::getGlobalAccess($table, $rid);
         }
         $access->saveData($data);
         $assignments = Assignments::getInstance();

--- a/_test/Validator.test.php
+++ b/_test/Validator.test.php
@@ -2,7 +2,9 @@
 
 namespace dokuwiki\plugin\struct\test;
 
+use dokuwiki\plugin\struct\meta\Column;
 use dokuwiki\plugin\struct\test\mock\Assignments;
+use dokuwiki\plugin\struct\test\mock\Lookup;
 use dokuwiki\plugin\struct\types\Decimal;
 use dokuwiki\plugin\struct\types\Text;
 
@@ -84,6 +86,17 @@ class Validator_struct_test extends StructTest {
         $value = array('  foo  ', '  bar  ');
         $this->assertTrue($validator->validateField($text, 'label', $value));
         $this->assertEquals(array('foo', 'bar'), $value);
+    }
+
+    public function test_validate_empty_multivalue() {
+        $lookup = new Lookup(null, '', true);
+        $col = new Column(10, $lookup);
+
+        $validator = new mock\ValueValidator();
+        $value = '';
+
+        $validator->validateValue($col, $value);
+        $this->assertEquals([''], $value);
     }
 
 }

--- a/_test/mock/AccessTable.php
+++ b/_test/mock/AccessTable.php
@@ -3,7 +3,6 @@
 namespace dokuwiki\plugin\struct\test\mock;
 
 use dokuwiki\plugin\struct\meta;
-use dokuwiki\plugin\struct\meta\AccessTableGlobal;
 use dokuwiki\plugin\struct\meta\Schema;
 
 abstract class AccessTable extends meta\AccessTable {
@@ -12,6 +11,12 @@ abstract class AccessTable extends meta\AccessTable {
     {
         $schema = new Schema($tablename, $ts);
         return new AccessTablePage($schema, $pid, $ts, 0);
+    }
+
+    public static function getGlobalAccess($tablename, $rid = 0)
+    {
+        $schema = new Schema($tablename, 0);
+        return new AccessTableGlobal($schema, '', 0, $rid);
     }
 
     /**

--- a/_test/mock/AccessTableGlobal.php
+++ b/_test/mock/AccessTableGlobal.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace dokuwiki\plugin\struct\test\mock;
+
+class AccessTableGlobal extends \dokuwiki\plugin\struct\meta\AccessTableGlobal {
+
+    public function getDataFromDB() {
+        return parent::getDataFromDB();
+    }
+}

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -210,7 +210,7 @@ abstract class AccessTable
                 // copy first value to the single column
                 if (isset($value[0])) {
                     $this->singleValues[] = $value[0];
-                    if (strlen($value[0]) === 0) {
+                    if ($value[0] === '') {
                         $this->handleEmptyMulti($this->pid, $this->rid, $colrefs[$colname]);
                     }
                 } else {

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -27,6 +27,8 @@ abstract class AccessTable
     // options on how to retrieve data
     protected $opt_skipempty = false;
 
+    protected $optQueries = [];
+
     /**
      * @var string Name of single-value table
      */
@@ -208,6 +210,9 @@ abstract class AccessTable
                 // copy first value to the single column
                 if (isset($value[0])) {
                     $this->singleValues[] = $value[0];
+                    if (strlen($value[0]) === 0) {
+                        $this->handleEmptyMulti($this->pid, $this->rid, $colrefs[$colname]);
+                    }
                 } else {
                     $this->singleValues[] = null;
                 }
@@ -239,6 +244,8 @@ abstract class AccessTable
                 );
             }
         }
+
+        $ok = $ok && $this->afterSave();
 
         if (!$ok) {
             $this->sqlite->query('ROLLBACK TRANSACTION');
@@ -304,6 +311,20 @@ abstract class AccessTable
     protected function afterSingleSave()
     {
         return true;
+    }
+
+    /**
+     * Executes final optional queries.
+     *
+     * @return bool False if anything goes wrong and transaction should be rolled back
+     */
+    protected function afterSave()
+    {
+        $ok = true;
+        foreach ($this->optQueries as $query) {
+            $ok = $ok && $this->sqlite->query(array_shift($query), $query);
+        }
+        return $ok;
     }
 
     /**
@@ -580,5 +601,17 @@ abstract class AccessTable
     public static function isTypeSerial($pid, $rev)
     {
         return $pid !== '' && $rev === 0;
+    }
+
+    /**
+     * Global and serial data require additional queries. They are put into query queue
+     * in ancestors of this method.
+     *
+     * @param string $pid
+     * @param int $rid
+     * @param int $colref
+     */
+    protected function handleEmptyMulti($pid, $rid, $colref)
+    {
     }
 }

--- a/meta/AccessTableGlobal.php
+++ b/meta/AccessTableGlobal.php
@@ -118,4 +118,20 @@ class AccessTableGlobal extends AccessTable
         }
         return $ok;
     }
+
+    /**
+     * Add an optional query to clear any previous multi values if the first one is empty.
+     * Allows for deleting multi values from the inline editor.
+     *
+     * @param string $pid
+     * @param int $rid
+     * @param int $colref
+     */
+    protected function handleEmptyMulti($pid, $rid, $colref)
+    {
+        $this->optQueries[] = [
+            "DELETE FROM ? WHERE pid = ? AND rid = ? AND colref = ?",
+            'multi_' . $this->schema->getTable(), $pid, $rid, $colref
+        ];
+    }
 }

--- a/meta/ValueValidator.php
+++ b/meta/ValueValidator.php
@@ -41,7 +41,8 @@ class ValueValidator
             $rawvalue = $type->splitValues($rawvalue);
         }
         // strip empty fields from multi vals
-        if (is_array($rawvalue)) {
+        // but keep at least one so we can properly delete multivalues on update
+        if (is_array($rawvalue) && count($rawvalue) > 1) {
             $rawvalue = array_filter($rawvalue, array($this, 'filter'));
             $rawvalue = array_values($rawvalue); // reset the array keys
         }


### PR DESCRIPTION
Fixes #439

Puts a mechanism in place to delete any previous values when saving an
empty multi field. This does NOT apply to page data, which is versioned
and should not be deleted on update.