### PR TITLE
Bureaucracy integration: use earlier event to handle lookup fields

### DIFF
--- a/action/bureaucracy.php
+++ b/action/bureaucracy.php
@@ -34,7 +34,7 @@ class action_plugin_struct_bureaucracy extends DokuWiki_Action_Plugin
      */
     public function register(Doku_Event_Handler $controller)
     {
-        $controller->register_hook('PLUGIN_BUREAUCRACY_TEMPLATE_SAVE', 'BEFORE', $this, 'handleLookupFields');
+        $controller->register_hook('PLUGIN_BUREAUCRACY_PAGENAME', 'BEFORE', $this, 'handleLookupFields');
         $controller->register_hook('PLUGIN_BUREAUCRACY_TEMPLATE_SAVE', 'AFTER', $this, 'handleSave');
         $controller->register_hook('PLUGIN_BUREAUCRACY_FIELD_UNKNOWN', 'BEFORE', $this, 'handleSchema');
     }


### PR DESCRIPTION
Switching to the earlier event allows replacing values in page ids. It does not affect data storage.

Fixes #483