### PR TITLE
Fix missing closing form tag

### DIFF
--- a/admin/assignments.php
+++ b/admin/assignments.php
@@ -154,6 +154,7 @@ class admin_plugin_struct_assignments extends DokuWiki_Admin_Plugin
         echo '</tr>';
 
         echo '</table>';
+        echo '</form>';
     }
 
     /**


### PR DESCRIPTION
Addresses my issue #531 

DokuWiki themes that do not use a form element for the search (like vector) would break the assignments form because this missing tag would cause other inputs on the page to be included.