### PR TITLE
Add option to remove single columns from wildcard select

### DIFF
--- a/meta/Search.php
+++ b/meta/Search.php
@@ -97,6 +97,14 @@ class Search
     public function addColumn($colname)
     {
         if ($this->processWildcard($colname)) return; // wildcard?
+        if ($colname[0] == '-') { // remove column from previous wildcard lookup
+           $colname = substr($colname, 1); 
+           foreach($this->columns as $key => $col){
+             if ($col->getLabel() == $colname) unset($this->columns[$key]);
+           }
+           return;
+        }
+        
         $col = $this->findColumn($colname);
         if (!$col) return; //FIXME do we really want to ignore missing columns?
         $this->columns[] = $col;


### PR DESCRIPTION
This allows the user to remove specific columns from wildcard lookup, e.g.

```
---- struct table ----
schema: foo
sort: plz
cols: %pageid%, *, -geo, -map
dynfilters: 1
----


```