### PR TITLE
Fix migration statement affecting some fields

### DIFF
--- a/action/migration.php
+++ b/action/migration.php
@@ -167,7 +167,7 @@ class action_plugin_struct_migration extends DokuWiki_Action_Plugin
                     $ok = $ok && $sqlite->query($s);
                     if (!$ok) return false;
                     // multi_
-                    $f = 'UPDATE multi_%s SET value = \'["value",0]\' WHERE colref = %s AND CAST(value AS DECIMAL) != value';
+                    $f = 'UPDATE multi_%s SET value = \'["\'||value||\'",0]\' WHERE colref = %s AND CAST(value AS DECIMAL) != value';
                     $s = sprintf($f, $name, $colno);
                     $ok = $ok && $sqlite->query($s);
                     if (!$ok) return false;


### PR DESCRIPTION
Multivalue lookup fields referencing page schemas got corrupted by error in SQL statement (`multi_` tables).

This PR fixes the old migration but does nothing with the broken data, since it cannot be recovered.

(It would be possible to fix the first value of the affected field, because it is stored correctly in the `data_` table as well. I'm not sure if this approach is a good idea, because we might be falsifying data without users noticing anything.)