### PR TITLE
Add config option to disable deleting serial data in aggregations

### DIFF
--- a/action/config.php
+++ b/action/config.php
@@ -22,6 +22,7 @@ class action_plugin_struct_config extends DokuWiki_Action_Plugin
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjax');
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'addJsinfo');
     }
 
     /**
@@ -46,5 +47,16 @@ class action_plugin_struct_config extends DokuWiki_Action_Plugin
 
         header('Content-Type: text/plain'); // we need the encoded string, not decoded by jQuery
         echo json_encode($type->getConfig());
+    }
+
+    /**
+     * Add config options to JSINFO
+     *
+     * @param Doku_Event $event
+     */
+    public function addJsinfo(Doku_Event $event)
+    {
+        global $JSINFO;
+        $JSINFO['plugins']['struct']['disableDeleteSerial'] = $this->getConf('disableDeleteSerial');
     }
 }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,3 +1,4 @@
 <?php
 
 $conf['bottomoutput'] = 0;
+$conf['disableDeleteSerial'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,3 +1,4 @@
 <?php
 
 $meta['bottomoutput'] = ['onoff'];
+$meta['disableDeleteSerial'] = ['onoff'];

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -35,6 +35,7 @@ $lang['del_fail']              = 'Die Schemanamen stimmten nicht überein. Schem
 $lang['del_ok']                = 'Schema wurde gelöscht';
 $lang['btn_delete']            = 'Löschen';
 $lang['js']['confirmAssignmentsDelete'] = 'Wollen Sie wirklich die Zuweisung von Schma "{0}" zu Seite/Namensraum "{1}" löschen?';
+$lang['js']['actions']         = 'Aktion';
 $lang['js']['lookup_delete']   = 'Lösche Eintrag';
 $lang['clear_confirm']         = 'Namen des Schema zur Bestätigung der Entfernung aller Daten eingeben';
 $lang['clear_fail']            = 'Die Schemanamen stimmten nicht überein. Daten wurden nicht entfernt';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -5,3 +5,4 @@
  *
  */
 $lang['bottomoutput']          = 'Daten am Ende der Seite anzeigen';
+$lang['disableDeleteSerial']   = 'Löschen von serial Daten deaktivieren';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -122,6 +122,7 @@ $lang['Exception schema missing'] = "Schema %s does not exist!";
 
 $lang['no_lookup_for_page'] = 'You can\'t use the Lookup Editor on a page schema!';
 $lang['lookup new entry'] = 'Create new Entry';
+$lang['js']['actions'] = 'Actions';
 $lang['js']['lookup_delete'] = 'Delete Entry';
 
 $lang['bureaucracy_action_struct_lookup_thanks'] = 'The entry has been stored. <a href="%s">Add another entry</a>.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,2 +1,3 @@
 <?php
 $lang['bottomoutput'] = 'Display data at the bottom of the page';
+$lang['disableDeleteSerial']   = 'Disable delete button for serial data';

--- a/script/AggregationEditor.js
+++ b/script/AggregationEditor.js
@@ -1,39 +1,47 @@
 /**
- * Lookup Editor
+ * Aggregation table editor
  */
-var AggregationEditor = function (idx, table) {
-    var $table = jQuery(table);
-    var $form = null;
-    var formdata;
+const AggregationEditor = function (idx, table) {
+    const $table = jQuery(table);
+    let $form = null;
+    let formdata;
 
-    var schema = $table.parents('.structaggregation').data('schema');
+    const schema = $table.parents('.structaggregation').data('schema');
     if (!schema) return;
 
     /**
      * Adds delete row buttons to each row
      */
     function addDeleteRowButtons() {
+        const disableDeleteSerial = JSINFO.plugins.struct.disableDeleteSerial;
+
         $table.find('tr').each(function () {
-            var $me = jQuery(this);
+            const $me = jQuery(this);
 
             // already added here?
             if ($me.find('th.action, td.action').length) {
                 return;
             }
 
-            var rid = $me.data('rid');
+            const rid = $me.data('rid');
+            const pid = $me.data('pid');
+            let isDisabled = '';
 
             // empty header cells
             if (!rid) {
-                $me.append('<th class="action"></th>');
+                $me.append('<th class="action">' + LANG.plugins.struct.actions + '</th>');
                 return;
             }
 
             // delete buttons for rows
-            var $td = jQuery('<td class="action"></td>');
-            if (rid === '') return;
+            const $td = jQuery('<td class="action"></td>');
+            if (rid === '') return;  // skip button addition for page data
+            // disable button for serial data if so configured
+            if (rid && pid && disableDeleteSerial) {
+                isDisabled = ' disabled';
+            }
 
-            var $btn = jQuery('<button><i class="ui-icon ui-icon-trash"></i></button>')
+            const $btn = jQuery('<button' + isDisabled + '><i class="ui-icon ui-icon-trash"></i></button>')
                 .addClass('delete')
                 .attr('title', LANG.plugins.struct.lookup_delete)
                 .click(function (e) {


### PR DESCRIPTION
This PR adds a simple config option that will render the `delete` button as disabled in rows listing serial data. 