### PR TITLE
Add config option to show data on the top of the page

### DIFF
--- a/action/output.php
+++ b/action/output.php
@@ -53,7 +53,6 @@ class action_plugin_struct_output extends DokuWiki_Action_Plugin
         if ($this->getConf('bottomoutput')) {
             $ins = count($event->data->calls);
         } else if (!$this->getConf('topoutput')) {
-            $ins = -1;
             foreach ($event->data->calls as $num => $call) {
                 // try to find the first header
                 if ($call[0] == 'header') {

--- a/action/output.php
+++ b/action/output.php
@@ -47,10 +47,12 @@ class action_plugin_struct_output extends DokuWiki_Action_Plugin
         if (!page_exists($ID)) return;
 
         $pos = 0;
+        $ins = -1;
+
         // display struct data at the bottom?
         if ($this->getConf('bottomoutput')) {
             $ins = count($event->data->calls);
-        } else {
+        } else if (!$this->getConf('topoutput')) {
             $ins = -1;
             foreach ($event->data->calls as $num => $call) {
                 // try to find the first header

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,4 +1,5 @@
 <?php
 
 $conf['bottomoutput'] = 0;
+$conf['topoutput'] = 0;
 $conf['disableDeleteSerial'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,4 +1,5 @@
 <?php
 
 $meta['bottomoutput'] = ['onoff'];
+$meta['topoutput'] = ['onoff'];
 $meta['disableDeleteSerial'] = ['onoff'];

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -5,4 +5,5 @@
  *
  */
 $lang['bottomoutput']          = 'Daten am Ende der Seite anzeigen';
+$lang['topoutput']             = 'Daten am Anfang der Seite anzeigen';
 $lang['disableDeleteSerial']   = 'Löschen von serial Daten deaktivieren';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,4 @@
 <?php
 $lang['bottomoutput'] = 'Display data at the bottom of the page';
+$lang['topoutput'] = 'Display data at the top of the page';
 $lang['disableDeleteSerial']   = 'Disable delete button for serial data';

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -10,3 +10,4 @@
  * @author Laynee <seedfloyd@gmail.com>
  */
 $lang['bottomoutput']          = 'Afficher les données au bas de la page';
+$lang['topoutput']             = 'Afficher les données en haut de la page';


### PR DESCRIPTION
Currently the default behavior is to show the data below the first heading if it is found, or else on the top of the page.
In addition to the existing option to always show the data on the bottom, let's also add an option to show it always on the top.

To make things simpler we use a single multi option config setting.