### PR TITLE
allow serial entries to be included

### DIFF
--- a/syntax/serial.php
+++ b/syntax/serial.php
@@ -30,9 +30,11 @@ class syntax_plugin_struct_serial extends syntax_plugin_struct_global
      */
     protected function addTypeFilter($config)
     {
-        global $ID;
+        // we get the main ID instead of using $ID, so that serial data entry can be used via includes
+        // $INFO is not set yet so it can't be used
+        $id = getID();
         $config['filter'][] = ['%rowid%', '!=', (string)AccessTablePage::DEFAULT_PAGE_RID, 'AND'];
-        $config['filter'][] = ['%pageid%', '=', $ID, 'AND'];
+        $config['filter'][] = ['%pageid%', '=', $id, 'AND'];
         $config['withpid'] = 1; // flag for the editor to distinguish data types
         return $config;
     }


### PR DESCRIPTION
It may make sense to define the serial entry mechanism in a central place and simply include it using the include plugin. This patch makes this possible, by always associating serial data with the "main" page instead of the page the syntax is in.