### PR TITLE
Never load serial data in page editor

### DIFF
--- a/_test/AccessTableDataDB.test.php
+++ b/_test/AccessTableDataDB.test.php
@@ -299,7 +299,8 @@ class AccessTableDataDB_struct_test extends StructTest {
                 'multipage' => array('wiki:dokuwiki', 'wiki:syntax', 'wiki:welcome'),
                 'singletitle' => 'wiki:dokuwiki',
                 'multititle' => array('wiki:dokuwiki', 'wiki:syntax', 'wiki:welcome'),
-            )
+            ),
+            time()
         );
 
         // make sure titles for some pages are known (not for wiki:welcome)

--- a/_test/AccessTableDataReplacement.test.php
+++ b/_test/AccessTableDataReplacement.test.php
@@ -42,13 +42,15 @@ class AccessTableDataReplacement_struct_test extends StructTest {
         $as->assignPageSchema('page2', 'bar');
         $as->assignPageSchema('page2', 'bar');
 
-
+        // page data is saved with a rev timestamp
+        $now = time();
         $this->saveData(
             'start',
             'foo',
             array(
                 'pages' => array('page1', 'page2')
-            )
+            ),
+            $now
         );
 
         $this->saveData(
@@ -56,7 +58,8 @@ class AccessTableDataReplacement_struct_test extends StructTest {
             'bar',
             array(
                 'data' => 'data of page1'
-            )
+            ),
+            $now
         );
 
         $this->saveData(
@@ -64,7 +67,8 @@ class AccessTableDataReplacement_struct_test extends StructTest {
             'bar',
             array(
                 'data' => 'data of page2'
-            )
+            ),
+            $now
         );
     }
 

--- a/_test/Search.test.php
+++ b/_test/Search.test.php
@@ -26,6 +26,7 @@ class Search_struct_test extends StructTest {
         $as->assignPageSchema($page, 'schema2');
         saveWikiText($page, "===== TestTitle =====\nabc", "Summary");
         p_get_metadata($page);
+        $now = time();
         $this->saveData(
             $page,
             'schema1',
@@ -34,7 +35,8 @@ class Search_struct_test extends StructTest {
                 'second' => array('second data', 'more data', 'even more'),
                 'third' => 'third data',
                 'fourth' => 'fourth data'
-            )
+            ),
+            $now
         );
         $this->saveData(
             $page,
@@ -44,7 +46,8 @@ class Search_struct_test extends StructTest {
                 'asecond' => array('second data', 'more data', 'even more'),
                 'athird' => 'third data',
                 'afourth' => 'fourth data'
-            )
+            ),
+            $now
         );
 
         $as->assignPageSchema('test:document', 'schema1');
@@ -57,7 +60,8 @@ class Search_struct_test extends StructTest {
                 'second' => array('second', 'more'),
                 'third' => '',
                 'fourth' => 'fourth data'
-            )
+            ),
+            $now
         );
         $this->saveData(
             'test:document',
@@ -67,7 +71,8 @@ class Search_struct_test extends StructTest {
                 'asecond' => array('second data', 'more data', 'even more'),
                 'athird' => 'third data',
                 'afourth' => 'fourth data'
-            )
+            ),
+            $now
         );
 
         for($i = 10; $i <= 20; $i++) {
@@ -79,7 +84,8 @@ class Search_struct_test extends StructTest {
                     'asecond' => array("page$i second data"),
                     'athird' => "page$i third data",
                     'afourth' => "page$i fourth data"
-                )
+                ),
+                $now
             );
             $as->assignPageSchema("page$i", 'schema2');
         }

--- a/_test/Type_Dropdown.test.php
+++ b/_test/Type_Dropdown.test.php
@@ -15,26 +15,30 @@ class Type_Dropdown_struct_test extends StructTest {
 
     protected function preparePages() {
         $this->loadSchemaJSON('dropdowns');
+        $now = time();
         $this->saveData(
             'test1',
             'dropdowns',
             [
                 'drop1' => '["test1",1]', 'drop2' => '["test1",1]', 'drop3' => 'John'
-            ]
+            ],
+            $now
         );
         $this->saveData(
             'test2',
             'dropdowns',
             [
                 'drop1' => '["test1",2]', 'drop2' => '["test1",2]', 'drop3' => 'Jane'
-            ]
+            ],
+            $now
         );
         $this->saveData(
             'test3',
             'dropdowns',
             [
                 'drop1' => '["test1",3]', 'drop2' => '["test1",3]', 'drop3' => 'Tarzan'
-            ]
+            ],
+            $now
         );
     }
 

--- a/_test/edit.test.php
+++ b/_test/edit.test.php
@@ -26,7 +26,8 @@ class edit_struct_test extends StructTest {
                 'second' => array('second data', 'more data', 'even more'),
                 'third' => 'third data',
                 'fourth' => 'fourth data'
-            )
+            ),
+            time()
         );
     }
 

--- a/_test/output.test.php
+++ b/_test/output.test.php
@@ -24,6 +24,7 @@ class output_struct_test extends StructTest {
 
         $page = 'page01';
         $includedPage = 'foo';
+        $now = time();
         $this->saveData(
             $page,
             'schema1',
@@ -32,7 +33,8 @@ class output_struct_test extends StructTest {
                 'second' => array('second data', 'more data', 'even more'),
                 'third' => 'third data',
                 'fourth' => 'fourth data'
-            )
+            ),
+            $now
         );
         $this->saveData(
             $page,
@@ -42,7 +44,8 @@ class output_struct_test extends StructTest {
                 'second field' => array('second data', 'more data', 'even more'),
                 'third%field' => 'third data',
                 'fourth.field?' => 'fourth data'
-            )
+            ),
+            $now
         );
         $this->saveData(
             $includedPage,
@@ -52,7 +55,8 @@ class output_struct_test extends StructTest {
                 'second' => array('second data', 'more data', 'even more'),
                 'third' => 'third data',
                 'fourth' => 'fourth data'
-            )
+            ),
+            $now
         );
     }
 


### PR DESCRIPTION
Previously the page data editor pulled anything from the database associated with the current page id and having rev <= current timestamp. This included serial data with rev = 0, which are now excluded.