### PR TITLE
Fixes for unit tests and a bug with struct variable evaluation in filters

### DIFF
--- a/_test/AccessTableDataDB.test.php
+++ b/_test/AccessTableDataDB.test.php
@@ -17,7 +17,7 @@ class AccessTableDataDB_struct_test extends StructTest {
     /** @var \helper_plugin_sqlite $sqlite */
     protected $sqlite;
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         /** @var \helper_plugin_struct_db $sqlite */

--- a/_test/AccessTableDataDBMulti.test.php
+++ b/_test/AccessTableDataDBMulti.test.php
@@ -19,7 +19,7 @@ class AccessTableDataDBMulti_struct_test extends StructTest {
     /** @var \helper_plugin_sqlite $sqlite */
     protected $sqlite;
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         /** @var \helper_plugin_struct_db $sqlite */

--- a/_test/AccessTableDataReplacement.test.php
+++ b/_test/AccessTableDataReplacement.test.php
@@ -16,7 +16,7 @@ class AccessTableDataReplacement_struct_test extends StructTest {
     /** @var array alway enable the needed plugins */
     protected $pluginsEnabled = array('struct', 'sqlite');
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
         $schemafoo = array();
         $schemafoo['new']['new1']['label'] = 'pages';

--- a/_test/AggregationExportCSV.test.php
+++ b/_test/AggregationExportCSV.test.php
@@ -14,7 +14,7 @@ use dokuwiki\plugin\struct\meta\ConfigParser;
 class AggregationExportCSV extends StructTest
 {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('wikilookup', '');

--- a/_test/AggregationResults.test.php
+++ b/_test/AggregationResults.test.php
@@ -20,7 +20,7 @@ class AggregationResults_struct_test extends StructTest
 {
     protected $sqlite;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/_test/Bureaucracy.test.php
+++ b/_test/Bureaucracy.test.php
@@ -20,7 +20,7 @@ class Bureaucracy_struct_test extends StructTest {
     /** @var array of lookup data */
     protected $lookup = array();
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('bureaucracy_lookup');

--- a/_test/ImportPageCSV.test.php
+++ b/_test/ImportPageCSV.test.php
@@ -13,7 +13,7 @@ use dokuwiki\plugin\struct\meta\Search;
 class ImportPageCSV extends StructTest
 {
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/_test/SchemaBuilder.test.php
+++ b/_test/SchemaBuilder.test.php
@@ -14,7 +14,7 @@ class schemaBuilder_struct_test extends StructTest {
     /** @var \helper_plugin_sqlite $sqlite */
     protected $sqlite;
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         /** @var \helper_plugin_struct_db $sqlite */

--- a/_test/Search.test.php
+++ b/_test/Search.test.php
@@ -13,7 +13,7 @@ use dokuwiki\plugin\struct\meta;
  */
 class Search_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');

--- a/_test/SearchConfigParameter.test.php
+++ b/_test/SearchConfigParameter.test.php
@@ -13,7 +13,7 @@ use dokuwiki\plugin\struct\meta;
  */
 class SearchConfigParameter_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');

--- a/_test/StructTest.php
+++ b/_test/StructTest.php
@@ -24,7 +24,7 @@ abstract class StructTest extends \DokuWikiTest {
      *
      * we always make sure the database is clear
      */
-    protected function tearDown() {
+    protected function tearDown() : void {
         parent::tearDown();
         /** @var \helper_plugin_struct_db $db */
         $db = plugin_load('helper', 'struct_db');

--- a/_test/Type_Page.test.php
+++ b/_test/Type_Page.test.php
@@ -14,7 +14,7 @@ use dokuwiki\plugin\struct\types\Page;
  */
 class Type_Page_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         saveWikiText('syntax', 'dummy', 'test');

--- a/_test/Type_Tag.test.php
+++ b/_test/Type_Tag.test.php
@@ -11,7 +11,7 @@ use dokuwiki\plugin\struct\types\Tag;
  */
 class Type_Tag_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
         $this->loadSchemaJSON('tag');
 

--- a/_test/Validator.test.php
+++ b/_test/Validator.test.php
@@ -17,7 +17,7 @@ use dokuwiki\plugin\struct\types\Text;
  */
 class Validator_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');
@@ -35,7 +35,7 @@ class Validator_struct_test extends StructTest {
         );
     }
 
-    protected function tearDown() {
+    protected function tearDown() : void {
         parent::tearDown();
 
         /** @var \helper_plugin_struct_db $sqlite */

--- a/_test/action/LookupAjaxAction..php
+++ b/_test/action/LookupAjaxAction..php
@@ -14,7 +14,7 @@ use dokuwiki\plugin\struct\test\StructTest;
  */
 class LookupAjaxAction extends StructTest
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/_test/diff.test.php
+++ b/_test/diff.test.php
@@ -16,7 +16,7 @@ use dokuwiki\plugin\struct\meta;
  */
 class diff_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');

--- a/_test/edit.test.php
+++ b/_test/edit.test.php
@@ -13,7 +13,7 @@ use dokuwiki\plugin\struct\meta;
  */
 class edit_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');

--- a/_test/helper_db.test.php
+++ b/_test/helper_db.test.php
@@ -10,7 +10,7 @@ use dokuwiki\plugin\struct\meta;
  */
 class helper_db_struct_test extends StructTest {
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');

--- a/_test/move.test.php
+++ b/_test/move.test.php
@@ -49,7 +49,7 @@ class move_struct_test extends StructTest {
         'titles' => array()
     );
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
         $this->loadSchemaJSON('moves');
 

--- a/_test/output.test.php
+++ b/_test/output.test.php
@@ -16,7 +16,7 @@ class output_struct_test extends StructTest {
     /** @var array add the extra plugins */
     protected $pluginsEnabled = array('struct', 'sqlite', 'log', 'include');
 
-    public function setUp() {
+    public function setUp() : void {
         parent::setUp();
 
         $this->loadSchemaJSON('schema1');

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -611,7 +611,7 @@ class Search
      * @param string $colname may contain an alias
      * @return bool|Column
      */
-    public function findColumn($colname)
+    public function findColumn($colname, $strict = false)
     {
         if (!$this->schemas) throw new StructException('noschemas');
         $schema_list = array_keys($this->schemas);
@@ -638,11 +638,17 @@ class Search
 
         list($colname, $table) = $this->resolveColumn($colname);
 
-        // if table name is given search only that, otherwise try all for matching column name
+        /*
+         * If table name is given search only that, otherwise if no strict behavior
+         * is requested by the caller, try all assigned schemas for matching the
+         * column name.
+         */
         if ($table !== null && isset($this->schemas[$table])) {
             $schemas = array($table => $this->schemas[$table]);
-        } else {
+        } else if ($table === null || !$strict) {
             $schemas = $this->schemas;
+        } else {
+            return false;
         }
 
         // find it

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -155,8 +155,8 @@ class SearchConfig extends Search
 
         $key = $match[2];
 
-        // we try to resolve the key via current schema aliases first, otherwise take it literally
-        $column = $this->findColumn($key);
+        // we try to resolve the key via the assigned schemas first, otherwise take it literally
+        $column = $this->findColumn($key, true);
         if ($column) {
             $label = $column->getLabel();
             $table = $column->getTable();


### PR DESCRIPTION
This is a mashup of three commits:

1. Fix unit tests by adding type hints for setUp() and tearDown()
2. Add more tests for struct filter variables and uncover a bug
3. Fix the previously uncovered bug

Please let me know if you have any comments or if you want separate PRs for these changes. Thanks!