### PR TITLE
Allow to move the struct data input to the top of the edit form

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -51,7 +51,9 @@ class action_plugin_struct_edit extends DokuWiki_Action_Plugin
 
         /** @var Form $form */
         $form = $event->data;
-        $pos = $form->findPositionByAttribute('id', 'wiki__editbar'); // insert the form before the main buttons
+        $pos = 0; // insert the form at the top
+        if (!$this->getConf('topoutput_edit'))
+            $pos = $form->findPositionByAttribute('id', 'wiki__editbar'); // insert the form before the main buttons
         $form->addHTML($html, $pos);
 
         return true;
@@ -73,7 +75,9 @@ class action_plugin_struct_edit extends DokuWiki_Action_Plugin
 
         /** @var Doku_Form $form */
         $form = $event->data;
-        $pos = $form->findElementById('wiki__editbar'); // insert the form before the main buttons
+        $pos = 0; // insert the form at the top
+        if (!$this->getConf('topoutput_edit'))
+            $pos = $form->findElementById('wiki__editbar'); // insert the form before the main buttons
         $form->insertElement($pos, $html);
 
         return true;

--- a/conf/default.php
+++ b/conf/default.php
@@ -2,4 +2,5 @@
 
 $conf['bottomoutput'] = 0;
 $conf['topoutput'] = 0;
+$conf['topoutput_edit'] = 0;
 $conf['disableDeleteSerial'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -2,4 +2,5 @@
 
 $meta['bottomoutput'] = ['onoff'];
 $meta['topoutput'] = ['onoff'];
+$meta['topoutput_edit'] = ['onoff'];
 $meta['disableDeleteSerial'] = ['onoff'];

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -6,4 +6,5 @@
  */
 $lang['bottomoutput']          = 'Daten am Ende der Seite anzeigen';
 $lang['topoutput']             = 'Daten am Anfang der Seite anzeigen';
+$lang['topoutput_edit']        = 'Eingabeformular am Anfang der Seite anzeigen';
 $lang['disableDeleteSerial']   = 'Löschen von serial Daten deaktivieren';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,4 +1,5 @@
 <?php
 $lang['bottomoutput'] = 'Display data at the bottom of the page';
 $lang['topoutput'] = 'Display data at the top of the page';
+$lang['topoutput_edit']        = 'Display input form at the top of the page';
 $lang['disableDeleteSerial']   = 'Disable delete button for serial data';


### PR DESCRIPTION
In order to show the input form at the top rather than below the input for the page content we introduce a new config option.

This change only makes sense in conjunction with splitbrain/dokuwiki#3485 as otherwise the toolbar gets separated from the main wiki content text input.