### PR TITLE
Add render format to context of event PLUGIN_STRUCT_RENDER_AGGREGATION_TABLE

### DIFF
--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -120,6 +120,7 @@ class AggregationTable
         $rendercontext = array(
             'table' => $this,
             'renderer' => $this->renderer,
+            'format' => $this->mode,
             'search' => $this->searchConfig,
             'columns' => $this->columns,
             'data' => $this->result


### PR DESCRIPTION
This was missing from the event context when the event was introduced. To use the format/mode in the event let's pass it in the context.