### PR TITLE
Fix for Issue #467 (Aggregation and metadata issue)

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -32,7 +32,6 @@ class helper_plugin_struct extends DokuWiki_Plugin
      * All descendants are also blacklisted.
      */
     const BLACKLIST_RENDERER = [
-        'Doku_Renderer_metadata',
         '\renderer_plugin_qc'
     ];
 

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -111,7 +111,9 @@ class SearchConfig extends Search
     {
         global $INFO;
         if (is_null($INFO)) {
-            $INFO = ['id' => null];
+            $pageinfo = pageinfo();
+        } else {
+            $pageinfo = $INFO;
         }
 
         // apply inexpensive filters first
@@ -124,9 +126,9 @@ class SearchConfig extends Search
                 '$TODAY$'
             ),
             array(
-                $INFO['id'],
-                getNS($INFO['id']),
-                noNS($INFO['id']),
+                $pageinfo['id'],
+                getNS($pageinfo['id']),
+                noNS($pageinfo['id']),
                 isset($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'] : '',
                 date('Y-m-d')
             ),

--- a/syntax/cloud.php
+++ b/syntax/cloud.php
@@ -84,7 +84,6 @@ class syntax_plugin_struct_cloud extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
-        if ($mode != 'xhtml') return false;
         if (!$data) return false;
         if (!empty($data['filter'])) {
             msg($this->getLang('Warning: no filters for cloud'), -1);

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -105,7 +105,6 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
-        if ($mode != 'xhtml') return false;
         if (!$data) return false;
         global $INFO;
         global $conf;

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -93,7 +93,6 @@ class syntax_plugin_struct_table extends DokuWiki_Syntax_Plugin
      */
     public function render($format, Doku_Renderer $renderer, $data)
     {
-        if ($mode != 'xhtml') return false;
         if (!$data) return false;
 
         global $INFO;

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -93,6 +93,7 @@ class syntax_plugin_struct_table extends DokuWiki_Syntax_Plugin
      */
     public function render($format, Doku_Renderer $renderer, $data)
     {
+        if ($mode != 'xhtml') return false;
         if (!$data) return false;
 
         global $INFO;


### PR DESCRIPTION
This will fix table aggregation links are stored in metadata. Originally lists and clouds were not rendered metadata, so I assume this line is accidentally excluded in tables.

P.S. It seems SQLite plugin ignores search filter in 'metadata' rendering mode. Because of it, documents with table aggregation may include unnesessary relation data in their metadata. So it's correct that #467 is problem, not intended function.

P.S.2. This code will not 'clear' metadata automatically. Admins must use another plugin for rebuilding metadata if they want to.