### PR TITLE
Remove form autofocus

### DIFF
--- a/script/AggregationEditor.js
+++ b/script/AggregationEditor.js
@@ -127,9 +127,6 @@ const AggregationEditor = function (idx, table) {
                     $errors.text(xhr.responseText).show();
                 })
         });
-
-        // focus first input
-        $form.find('input, textarea').first().focus();
     }
 
     /**


### PR DESCRIPTION
Automatic focus can be confusing or irritating, and is not very useful in the aggregation entry form.

Fixes #597