### PR TITLE
Fixed issue #437, filtering DateTime

### DIFF
--- a/_test/AggregationResults.test.php
+++ b/_test/AggregationResults.test.php
@@ -106,6 +106,22 @@ class AggregationResults_struct_test extends StructTest
     }
 
     /**
+     * Test filtering on a DateTime field
+     */
+    public function test_filter_datetime() {
+        $this->prepareDatetime();
+        $schema = 'datetime';
+        $result = $this->fetchResult($schema);
+        $this->assertEquals(3, count($result));
+
+        $result = $this->fetchResult($schema, '', ['field', '<', '2023-01-02', 'AND']);
+        $this->assertEquals(1, count($result));
+
+        $result = $this->fetchResult($schema, '', ['field', '<', '2023-01-01 11:00', 'AND']);
+        $this->assertEquals(0, count($result));
+    }
+
+    /**
      * Test whether aggregation tables respect revoking of schema assignments
      */
     public function test_assignments()
@@ -215,5 +231,16 @@ class AggregationResults_struct_test extends StructTest
                 'multititle' => array('title3'),
             )
         );
+    }
+
+    protected function prepareDatetime()
+    {
+        $this->loadSchemaJSON('datetime');
+        $access = AccessTable::getGlobalAccess('datetime');
+        $access->saveData(array('field' => '2023-01-01 12:00'));
+        $access = AccessTable::getGlobalAccess('datetime');
+        $access->saveData(array('field' => '2023-01-02 00:00'));
+        $access = AccessTable::getGlobalAccess('datetime');
+        $access->saveData(array('field' => '2023-01-02 12:00'));
     }
 }

--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -127,10 +127,10 @@ class DateTime extends Date
     public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
     {
         $col = "$tablealias.$colname";
+        $QB = $add->getQB();
 
         // when accessing the revision column we need to convert from Unix timestamp
         if (is_a($this->context, 'dokuwiki\plugin\struct\meta\RevisionColumn')) {
-            $QB = $add->getQB();
             $rightalias = $QB->generateTableAlias();
             $col = "DATETIME($rightalias.lastrev, 'unixepoch', 'localtime')";
             $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");


### PR DESCRIPTION
Applying a filter on a DateTime column in an aggregation was causing an uncaught error to occur and prevent the page being rendered at all (see #437). Fortunately, this turned out to be a very simple issue to resolve; it was just an issue with a variable not being declared in the right place.