### PR TITLE
Fix metadata rendering problem

### DIFF
--- a/_test/SearchConfig.test.php
+++ b/_test/SearchConfig.test.php
@@ -131,6 +131,30 @@ class SearchConfig_struct_test extends StructTest
         $this->assertEquals(array('user', 'test'), $searchConfig->applyFilterVars('$USER.grps$'));
     }
 
+    public function test_metadata_render()
+    {
+        $searchConfig = new SearchConfig(array("limit" => 50), true);
+        $reflection = new \ReflectionClass(get_class($searchConfig));
+        $rangeVar = $reflection->getProperty('range_end');
+        $rangeVar->setAccessible(true);
+        $dynamicFilterVar = $reflection->getProperty('dynamicParameters');
+        $dynamicFilterVar->setAccessible(true);
+
+        $this->assertTrue($rangeVar->getValue($searchConfig) == 0);
+        $this->assertTrue(is_null($dynamicFilterVar->getValue($searchConfig)));
+        $this->assertTrue(is_null($searchConfig->getDynamicParameters()));
+
+        $searchConfig = new SearchConfig(array("limit" => 50), false);
+        $this->assertTrue($rangeVar->getValue($searchConfig) == 50);
+        $this->assertFalse(is_null($dynamicFilterVar->getValue($searchConfig)));
+        $this->assertFalse(is_null($searchConfig->getDynamicParameters()));
+
+        $searchConfig = new SearchConfig(array("limit" => 50));
+        $this->assertTrue($rangeVar->getValue($searchConfig) == 50);
+        $this->assertFalse(is_null($dynamicFilterVar->getValue($searchConfig)));
+        $this->assertFalse(is_null($searchConfig->getDynamicParameters()));
+    }
+
     public function test_cacheflags()
     {
         $searchConfig = new SearchConfig(array());

--- a/_test/mock/SearchConfig.php
+++ b/_test/mock/SearchConfig.php
@@ -6,9 +6,9 @@ use dokuwiki\plugin\struct\meta;
 
 class SearchConfig extends meta\SearchConfig
 {
-    public function applyFilterVars($filter)
+    public function applyFilterVars($filter, $isMetadataRender = false)
     {
-        return parent::applyFilterVars($filter);
+        return parent::applyFilterVars($filter, $isMetadataRender);
     }
 
     public function determineCacheFlag($filters)

--- a/helper.php
+++ b/helper.php
@@ -31,7 +31,6 @@ class helper_plugin_struct extends DokuWiki_Plugin
      * All descendants are also blacklisted.
      */
     public const BLACKLIST_RENDERER = [
-        'Doku_Renderer_metadata',
         '\renderer_plugin_qc'
     ];
 

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -36,10 +36,9 @@ class SearchConfig extends Search
     /**
      * SearchConfig constructor.
      * @param array $config The parsed configuration for this search
-     * @param bool $applyDynamicFilter If this is true, then dynamic filters will not be parsed.
-     *                             This is for metadata rendering.
+     * @param bool $isMetadataRender If this is true, then dynamic filters will not be parsed.
      */
-    public function __construct($config, $applyDynamicFilter=false)
+    public function __construct($config, $isMetadataRender=false)
     {
         parent::__construct();
 
@@ -56,21 +55,21 @@ class SearchConfig extends Search
         if (!empty($config['filters'])) $this->cacheFlag = $this->determineCacheFlag($config['filters']);
 
         // apply dynamic paramters
-        if (!$applyDynamicFilter) {
+        if (!$isMetadataRender) {
             $this->dynamicParameters = new SearchConfigParameters($this);
             $config = $this->dynamicParameters->updateConfig($config);
         }
 
         // configure search from configuration
         if (!empty($config['filter'])) foreach ($config['filter'] as $filter) {
-            $this->addFilter($filter[0], $this->applyFilterVars($filter[2]), $filter[1], $filter[3]);
+            $this->addFilter($filter[0], $this->applyFilterVars($filter[2], $isMetadataRender), $filter[1], $filter[3]);
         }
 
         if (!empty($config['sort'])) foreach ($config['sort'] as $sort) {
             $this->addSort($sort[0], $sort[1]);
         }
 
-        if (!empty($config['limit']) && !$applyDynamicFilter) {
+        if (!empty($config['limit']) && !$isMetadataRender) {
             $this->setLimit($config['limit']);
         }
 
@@ -110,11 +109,11 @@ class SearchConfig extends Search
      * @param string $filter
      * @return string|string[] Result may be an array when a multi column placeholder is used
      */
-    protected function applyFilterVars($filter)
+    protected function applyFilterVars($filter, $isMetadataRender=false)
     {
         global $INFO;
         
-        if (is_null($INFO)) {
+        if (is_null($INFO) || $isMetadataRender) {
             $pageinfo = pageinfo();
         } else {
             $pageinfo = $INFO;

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -36,10 +36,10 @@ class SearchConfig extends Search
     /**
      * SearchConfig constructor.
      * @param array $config The parsed configuration for this search
-     * @param bool $renderMetadata If this is true, then dynamic filters will not be parsed.
+     * @param bool $applyDynamicFilter If this is true, then dynamic filters will not be parsed.
      *                             This is for metadata rendering.
      */
-    public function __construct($config, $renderMetadata=false)
+    public function __construct($config, $applyDynamicFilter=false)
     {
         parent::__construct();
 
@@ -56,7 +56,7 @@ class SearchConfig extends Search
         if (!empty($config['filters'])) $this->cacheFlag = $this->determineCacheFlag($config['filters']);
 
         // apply dynamic paramters
-        if (!$renderMetadata) {
+        if (!$applyDynamicFilter) {
             $this->dynamicParameters = new SearchConfigParameters($this);
             $config = $this->dynamicParameters->updateConfig($config);
         }
@@ -70,7 +70,7 @@ class SearchConfig extends Search
             $this->addSort($sort[0], $sort[1]);
         }
 
-        if (!empty($config['limit']) && !$renderMetadata) {
+        if (!empty($config['limit']) && !$applyDynamicFilter) {
             $this->setLimit($config['limit']);
         }
 
@@ -114,8 +114,6 @@ class SearchConfig extends Search
     {
         global $INFO;
         
-        if (!isset($INFO['id'])) {
-            $INFO['id'] = null;
         if (is_null($INFO)) {
             $pageinfo = pageinfo();
         } else {

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -236,11 +236,15 @@ class SearchConfig extends Search
      *
      * Note: This call returns a clone of the parameters as they were initialized
      *
-     * @return SearchConfigParameters
+     * @return SearchConfigParameters|null
      */
     public function getDynamicParameters()
     {
-        return clone $this->dynamicParameters;
+        if (isset($this->dynamicParameters)) {
+            return clone $this->dynamicParameters;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/syntax/cloud.php
+++ b/syntax/cloud.php
@@ -85,14 +85,22 @@ class syntax_plugin_struct_cloud extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
+        if ($mode != "metadata" && $mode != "xhtml") return false;
         if (!$data) return false;
         if (!empty($data['filter'])) {
             msg($this->getLang('Warning: no filters for cloud'), -1);
         }
         global $INFO, $conf;
+
+        if (is_null($INFO)) {
+            $pageinfo = pageinfo();
+        } else {
+            $pageinfo = $INFO;
+        }
+
         try {
             $search = new SearchCloud($data);
-            $cloud = new AggregationCloud($INFO['id'], $mode, $renderer, $search);
+            $cloud = new AggregationCloud($pageinfo['id'], $mode, $renderer, $search);
             $cloud->render();
             if ($mode == 'metadata') {
                 /** @var Doku_Renderer_metadata $renderer */

--- a/syntax/cloud.php
+++ b/syntax/cloud.php
@@ -85,7 +85,6 @@ class syntax_plugin_struct_cloud extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
-        if ($mode != 'xhtml') return false;
         if (!$data) return false;
         if (!empty($data['filter'])) {
             msg($this->getLang('Warning: no filters for cloud'), -1);

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -96,7 +96,7 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
     /**
      * Render xhtml output or metadata
      *
-     * @param string $mode Renderer mode (supported modes: xhtml)
+     * @param string $mode Renderer mode
      * @param Doku_Renderer $renderer The renderer
      * @param array $data The data from the handler() function
      * @return bool If rendering was successful.
@@ -108,7 +108,7 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
         global $INFO;
         global $conf;
 
-        if (is_null($INFO)) {
+        if (is_null($INFO) || $mode == "metadata") {
             $pageinfo = pageinfo();
         } else {
             $pageinfo = $INFO;
@@ -126,6 +126,7 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
                 /** @var Doku_Renderer_metadata $renderer */
                 $renderer->meta['plugin']['struct']['hasaggregation'] = $search->getCacheFlag();
             }
+            
         } catch (StructException $e) {
             msg($e->getMessage(), -1, $e->getLine(), $e->getFile());
             if ($conf['allowdebug']) msg('<pre>' . hsc($e->getTraceAsString()) . '</pre>', -1);

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -103,16 +103,23 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
+        if ($mode != "metadata" && $mode != "xhtml") return false;
         if (!$data) return false;
         global $INFO;
         global $conf;
+
+        if (is_null($INFO)) {
+            $pageinfo = pageinfo();
+        } else {
+            $pageinfo = $INFO;
+        }
 
         try {
             $this->checkForInvalidOptions($data);
             $search = new SearchConfig($data);
 
             /** @var AggregationList $list */
-            $list = new $this->tableclass($INFO['id'], $mode, $renderer, $search);
+            $list = new $this->tableclass($pageinfo['id'], $mode, $renderer, $search);
             $list->render();
 
             if ($mode == 'metadata') {

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -103,7 +103,6 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
-        if ($mode != 'xhtml') return false;
         if (!$data) return false;
         global $INFO;
         global $conf;

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -13,7 +13,7 @@ use dokuwiki\plugin\struct\meta\StructException;
 
 class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin
 {
-    protected $hasBeenRendered = false;
+    protected $hasBeenRendered = array('metadata'=>false, 'xhtml'=>false);
 
     protected const XHTML_OPEN = '<div id="plugin__struct_output">';
     protected const XHTML_CLOSE = '</div>';
@@ -97,13 +97,20 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin
                 return true;
             }
         }
-        if ($ID != $INFO['id']) return true;
-        if (!$INFO['exists']) return true;
-        if ($this->hasBeenRendered) return true;
+        if ($ID != pageinfo()['id']) return true;
+        if (!page_exists($ID)) return true;
+        if ($this->hasBeenRendered['metadata'] && $format == 'metadata') return true;
+        if ($this->hasBeenRendered['xhtml'] && $format == 'xhtml') return true;
         if (!preg_match(self::WHITELIST_ACTIONS, act_clean($ACT))) return true;
 
         // do not render the output twice on the same page, e.g. when another page has been included
-        $this->hasBeenRendered = true;
+        if ($format == 'metadata') {
+            $this->hasBeenRendered['metadata'] = true;
+        }
+        else if ($format == 'xhtml') {
+            $this->hasBeenRendered['xhtml'] = true;
+        }
+        
         try {
             $assignments = Assignments::getInstance();
         } catch (StructException $e) {

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -98,7 +98,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin
             }
         }
 
-        if (!isset($INFO)) {
+        if (!isset($INFO) || $format == "metadata") {
             $pagename = pageinfo()['id'];
         } else {
             $pagename = $INFO['id'];
@@ -117,7 +117,7 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin
         else if ($format == 'xhtml') {
             $this->hasBeenRendered['xhtml'] = true;
         }
-        
+
         try {
             $assignments = Assignments::getInstance();
         } catch (StructException $e) {

--- a/syntax/output.php
+++ b/syntax/output.php
@@ -97,8 +97,15 @@ class syntax_plugin_struct_output extends DokuWiki_Syntax_Plugin
                 return true;
             }
         }
-        if ($ID != pageinfo()['id']) return true;
-        if (!page_exists($ID)) return true;
+
+        if (!isset($INFO)) {
+            $pagename = pageinfo()['id'];
+        } else {
+            $pagename = $INFO['id'];
+        }
+
+        if ($ID != $pagename) return true;
+        if (!page_exists($pagename)) return true;
         if ($this->hasBeenRendered['metadata'] && $format == 'metadata') return true;
         if ($this->hasBeenRendered['xhtml'] && $format == 'xhtml') return true;
         if (!preg_match(self::WHITELIST_ACTIONS, act_clean($ACT))) return true;

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -96,7 +96,7 @@ class syntax_plugin_struct_table extends DokuWiki_Syntax_Plugin
         $config = $this->addTypeFilter($config); // add type specific filters
 
         try {
-            $search = new SearchConfig($config);
+            $search = new SearchConfig($config, $format == 'metadata');
             if ($format === 'struct_csv') {
                 // no pagination in export
                 $search->setLimit(0);


### PR DESCRIPTION
Fix various issues with metadata render.

Current code has following problems, with metadata rendering.
* List and cloud internal links are not be rendered to metadata.
* Table filters ARE NOT be correctly applied to metadata rendering. This means, EVERY pages will be added as internal link to metadata, regardless of table filter options. As a result, backlinks of page will contain non-related pages.
* Dynamic filters and limit parameter ARE applied to metadata rendering. This means every time dynamic filter is applied or user visit another page of table, backlinks will also be changed dynamically. This will delete related pages from backlink.

This pull request resolves above problems with following solution:
* Enable list and cloud metadata rendering
* In metadata rendering, dynamic filters and limit parameter will be ignored. To achieve this, I edited code so that syntax can be rendered twice; metadata and xhtml.

I tested this code with my personal wiki, which has 1,200 pages and a lot of struct aggregation. But if I missed something, please let me know.