### PR TITLE
PHP8 fix

### DIFF
--- a/meta/ConfigParser.php
+++ b/meta/ConfigParser.php
@@ -42,6 +42,7 @@ class ConfigParser
         );
         // parse info
         foreach ($lines as $line) {
+            if (!$line) continue;
             list($key, $val) = array_pad($this->splitLine($line), 2, '');
             if (!$key) continue;
 


### PR DESCRIPTION
This fixes an error in PHP8:
```
struct/meta/ConfigParser.php(45)	TypeError: array_pad(): Argument #1 ($array) must be of type array, bool given
```