### PR TITLE
Setup .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.* export-ignore
+/_test export-ignore


### PR DESCRIPTION
This is to exclude unrelated files for installation:
- .gitattributes
- .github/auto-comment.yml
- .github/workflows/phpCS.yml
- .github/workflows/phpTestLinux.yml
- .travis.yml
- _test

github zip export will exclude these files consulting `.gitattributes` file.

you can have preview of this of this pr's branch:
- https://github.com/glensc/dokuwiki-plugin-struct/archive/refs/heads/git-export.zip