### PR TITLE
Nested Lists

### DIFF
--- a/_test/ConfigParserTest.php
+++ b/_test/ConfigParserTest.php
@@ -82,7 +82,8 @@ class ConfigParserTest extends StructTest
                 ],
             'csv' => true,
             'target' => '',
-            'align' => ['right', 'left', 'center', null]
+            'align' => ['right', 'left', 'center', null],
+            'nesting' => 0,
         ];
 
         $this->assertEquals($expected_config, $actual_config);

--- a/_test/InlineConfigParserTest.php
+++ b/_test/InlineConfigParserTest.php
@@ -51,6 +51,7 @@ class InlineConfigParserTest extends StructTest
             'summarize' => false,
             'target' => '',
             'widths' => [],
+            'nesting' => 0,
         ];
 
         $this->assertEquals($expected_config, $actual_config);

--- a/_test/NestedResultTest.php
+++ b/_test/NestedResultTest.php
@@ -7,6 +7,13 @@ use dokuwiki\plugin\struct\meta\NestedResult;
 use dokuwiki\plugin\struct\meta\Value;
 use dokuwiki\plugin\struct\types\Text;
 
+/**
+ * Tests for the NestedResult class
+ *
+ * @group plugin_struct
+ * @group plugins
+ *
+ */
 class NestedResultTest extends StructTest
 {
     protected $simpleItems = [

--- a/_test/NestedResultTest.php
+++ b/_test/NestedResultTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace dokuwiki\plugin\struct\test;
+
+use dokuwiki\plugin\struct\meta\Column;
+use dokuwiki\plugin\struct\meta\NestedResult;
+use dokuwiki\plugin\struct\meta\Value;
+use dokuwiki\plugin\struct\types\Text;
+
+class NestedResultTest extends StructTest
+{
+    protected $simpleItems = [
+        ['car', 'audi', 'a80'],
+        ['car', 'audi', 'a4'],
+        ['car', 'audi', 'quattro'],
+        ['car', 'bmw', 'i3'],
+        ['car', 'bmw', 'mini'],
+        ['car', 'bmw', 'z1'],
+        ['laptop', 'apple', 'pro 16'],
+        ['laptop', 'apple', 'air'],
+        ['laptop', 'apple', 'm1'],
+        ['laptop', 'dell', 'xps'],
+        ['laptop', 'dell', 'inspiron'],
+        ['laptop', 'dell', 'latitude'],
+    ];
+
+    protected $multiItems = [
+        [['green', 'yellow'], 'car', 'audi', 'a80'],
+        [['yellow', 'blue'], 'car', 'audi', 'a4'],
+        [['black', 'green'], 'car', 'audi', 'quattro'],
+        [['red', 'black'], 'car', 'bmw', 'i3'],
+        [['blue', 'gray'], 'car', 'bmw', 'mini'],
+        [['red', 'black'], 'car', 'bmw', 'z1'],
+        [['green', 'blue'], 'laptop', 'apple', 'pro 16'],
+        [['red', 'blue'], 'laptop', 'apple', 'air'],
+        [['black', 'red'], 'laptop', 'apple', 'm1'],
+        [['gray', 'green'], 'laptop', 'dell', 'xps'],
+        [['blue', 'yellow'], 'laptop', 'dell', 'inspiron'],
+        [['gray', 'yellow'], 'laptop', 'dell', 'latitude'],
+    ];
+
+
+    /**
+     * Create a result set from a given flat array
+     * @param array $rows
+     * @return array
+     */
+    protected function makeResult($rows)
+    {
+        $result = [];
+
+        foreach ($rows as $row) {
+            $resultRow = [];
+            foreach ($row as $cell) {
+                $resultRow[] = new Value(
+                    new Column(
+                        10,
+                        new Text(null, '', is_array($cell)),
+                        0,
+                        true,
+                        'test'
+                    ),
+                    $cell
+                );
+            }
+            $result[] = $resultRow;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Don't nest at all
+     */
+    public function testSimpleZeroLevel()
+    {
+        $result = $this->makeResult($this->simpleItems);
+        $nestedResult = new NestedResult($result);
+        $root = $nestedResult->getRoot(0);
+
+        $this->assertCount(0, $root->getChildren(), 'no children expected');
+        $this->assertCount(12, $root->getResultRows(), '12 result rows expected');
+    }
+
+
+    /**
+     * Nest by the first level, no multi values
+     */
+    public function testSimpleOneLevel()
+    {
+        $result = $this->makeResult($this->simpleItems);
+        $nestedResult = new NestedResult($result);
+        $tree = $nestedResult->getRoot(1)->getChildren();
+
+        $this->assertCount(2, $tree, '2 root nodes expected');
+        $this->assertEquals('car', $tree[0]->getValueObject()->getValue());
+        $this->assertEquals('laptop', $tree[1]->getValueObject()->getValue());
+
+        $this->assertCount(0, $tree[0]->getChildren(), 'no children expected');
+        $this->assertCount(0, $tree[1]->getChildren(), 'no children expected');
+
+        $this->assertCount(6, $tree[0]->getResultRows(), 'result rows');
+        $this->assertCount(6, $tree[1]->getResultRows(), 'result rows');
+
+        $this->assertEquals('a80', $tree[0]->getResultRows()[0][1]->getValue(), 'Audi 80 expected');
+        $this->assertEquals('pro 16', $tree[1]->getResultRows()[0][1]->getValue(), 'Mac Pro 16 expected');
+    }
+
+
+    /**
+     * Nest by two levels, no multi values
+     */
+    public function testSimpleTwoLevels()
+    {
+        $result = $this->makeResult($this->simpleItems);
+        $nestedResult = new NestedResult($result);
+        $tree = $nestedResult->getRoot(2)->getChildren();
+
+        $this->assertCount(2, $tree, '2 root nodes expected');
+        $this->assertEquals('car', $tree[0]->getValueObject()->getValue());
+        $this->assertEquals('laptop', $tree[1]->getValueObject()->getValue());
+
+        $this->assertCount(2, $tree[0]->getChildren(), '2 second level nodes expected');
+        $this->assertCount(2, $tree[1]->getChildren(), '2 second level nodes expected');
+
+        $this->assertCount(3, $tree[0]->getChildren()[0]->getResultRows(), 'result rows');
+        $this->assertCount(3, $tree[0]->getChildren()[1]->getResultRows(), 'result rows');
+        $this->assertCount(3, $tree[1]->getChildren()[0]->getResultRows(), 'result rows');
+        $this->assertCount(3, $tree[1]->getChildren()[1]->getResultRows(), 'result rows');
+
+
+        $this->assertEquals('a80', $tree[0]->getChildren()[0]->getResultRows()[0][0]->getValue(), 'Audi 80 expected');
+        $this->assertEquals('pro 16', $tree[1]->getChildren()[0]->getResultRows()[0][0]->getValue(), 'Mac Pro 16 expected');
+    }
+
+    public function testMultiTwoLevels()
+    {
+        $result = $this->makeResult($this->multiItems);
+        $nestedResult = new NestedResult($result);
+        $tree = $nestedResult->getRoot(3)->getChildren(); // nest: color, type, brand -> model
+
+        $this->assertCount(6, $tree, '6 root nodes of colors expected');
+
+        // Values on the first level will be multi-values, thus returning arrays
+        $this->assertEquals('black', $tree[0]->getValueObject()->getValue()[0]);
+        $this->assertEquals('blue', $tree[1]->getValueObject()->getValue()[0]);
+        $this->assertEquals('gray', $tree[2]->getValueObject()->getValue()[0]);
+        $this->assertEquals('green', $tree[3]->getValueObject()->getValue()[0]);
+        $this->assertEquals('red', $tree[4]->getValueObject()->getValue()[0]);
+        $this->assertEquals('yellow', $tree[5]->getValueObject()->getValue()[0]);
+
+        // Results should now show up under multiple top-level nodes
+        $this->assertEquals('a80',
+            $tree[3] // green
+            ->getChildren()[0] // car
+            ->getChildren()[0] // audi
+            ->getResultRows()[0][0] // a80
+            ->getValue(),
+            'green car audi a80 expected'
+        );
+        $this->assertEquals('a80',
+            $tree[5] // yellow
+            ->getChildren()[0] // car
+            ->getChildren()[0] // audi
+            ->getResultRows()[0][0] // a80
+            ->getValue(),
+            'yellow car audi a80 expected'
+        );
+    }
+
+}

--- a/meta/Aggregation.php
+++ b/meta/Aggregation.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+/**
+ * Base contract for Aggregations
+ *
+ * @package dokuwiki\plugin\struct\meta
+ */
+abstract class Aggregation {
+
+    /** @var string the page id of the page this is rendered to */
+    protected $id;
+
+    /** @var string the Type of renderer used */
+    protected $mode;
+
+    /** @var \Doku_Renderer the DokuWiki renderer used to create the output */
+    protected $renderer;
+
+    /** @var SearchConfig the configured search - gives access to columns etc. */
+    protected $searchConfig;
+
+    /** @var Column[] the list of columns to be displayed */
+    protected $columns;
+
+    /** @var  Value[][] the search result */
+    protected $result;
+
+    /** @var int number of all results */
+    protected $resultCount;
+
+    /**
+     * @todo we might be able to get rid of this helper and move this to SearchConfig
+     * @var \helper_plugin_struct_config
+     */
+    protected $helper;
+
+    /**
+     * @var array the original configuration data
+     */
+    protected $data;
+
+    /**
+     * Initialize the Aggregation renderer and executes the search
+     *
+     * You need to call @param string $id
+     * @param string $mode
+     * @param \Doku_Renderer $renderer
+     * @param SearchConfig $searchConfig
+     * @see render() on the resulting object.
+     *
+     */
+    public function __construct($id, $mode, \Doku_Renderer $renderer, SearchConfig $searchConfig)
+    {
+        $this->id = $id;
+        $this->mode = $mode;
+        $this->renderer = $renderer;
+        $this->searchConfig = $searchConfig;
+        $this->data = $searchConfig->getConf();
+        $this->columns = $searchConfig->getColumns();
+        $this->result = $this->searchConfig->execute();
+        $this->resultCount = $this->searchConfig->getCount();
+        $this->helper = plugin_load('helper', 'struct_config');
+    }
+
+    /**
+     * Returns the page id the aggregation is used on
+     */
+    public function getID()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Create the table on the renderer
+     * 
+     * @param bool $showNotFound show a not found message when no data available?
+     */
+    abstract public function render($showNotFound = false);
+
+}

--- a/meta/AggregationCloud.php
+++ b/meta/AggregationCloud.php
@@ -2,42 +2,13 @@
 
 namespace dokuwiki\plugin\struct\meta;
 
-class AggregationCloud
+class AggregationCloud extends Aggregation
 {
-    /**
-     * @var string the page id of the page this is rendered to
-     */
-    protected $id;
+    /** @var int */
+    protected $max;
 
-    /**
-     * @var string the Type of renderer used
-     */
-    protected $mode;
-
-    /**
-     * @var \Doku_Renderer the DokuWiki renderer used to create the output
-     */
-    protected $renderer;
-
-    /**
-     * @var SearchConfig the configured search - gives access to columns etc.
-     */
-    protected $searchConfig;
-
-    /**
-     * @var Column[] the list of columns to be displayed
-     */
-    protected $columns;
-
-    /**
-     * @var  Value[][] the search result
-     */
-    protected $result;
-
-    /**
-     * @var int number of all results
-     */
-    protected $resultCount;
+    /** @var int */
+    protected $min;
 
     /**
      * Initialize the Aggregation renderer and executes the search
@@ -51,27 +22,16 @@ class AggregationCloud
      */
     public function __construct($id, $mode, \Doku_Renderer $renderer, SearchCloud $searchConfig)
     {
-        $this->id = $id;
-        $this->mode = $mode;
-        $this->renderer = $renderer;
-        $this->searchConfig = $searchConfig;
-        $this->data = $searchConfig->getConf();
-        $this->columns = $searchConfig->getColumns();
-        $this->result = $this->searchConfig->execute();
-        $this->resultCount = $this->searchConfig->getCount();
+        parent::__construct($id, $mode, $renderer, $searchConfig);
 
         $this->max = $this->result[0]['count'];
         $this->min = end($this->result)['count'];
     }
 
-    /**
-     * Create the cloud on the renderer
-     */
-    public function render()
+    /** @inheritdoc */
+    public function render($showNotFound = false)
     {
-
         $this->sortResults();
-
         $this->startScope();
         $this->startList();
         foreach ($this->result as $result) {
@@ -79,7 +39,6 @@ class AggregationCloud
         }
         $this->finishList();
         $this->finishScope();
-        return;
     }
 
     /**

--- a/meta/AggregationEditorTable.php
+++ b/meta/AggregationEditorTable.php
@@ -11,10 +11,12 @@ namespace dokuwiki\plugin\struct\meta;
  */
 class AggregationEditorTable extends AggregationTable
 {
-    /**
-     * @var bool skip full table when no results found
-     */
-    protected $simplenone = false;
+    /** @inheritdoc */
+    public function render($showNotFound = false)
+    {
+        parent::render(); // never show not found
+    }
+
 
     /**
      * Adds additional info to document and renderer in XHTML mode

--- a/meta/AggregationList.php
+++ b/meta/AggregationList.php
@@ -7,74 +7,30 @@ namespace dokuwiki\plugin\struct\meta;
  *
  * @package dokuwiki\plugin\struct\meta
  */
-class AggregationList
+class AggregationList extends Aggregation
 {
-    /**
-     * @var string the page id of the page this is rendered to
-     */
-    protected $id;
-    /**
-     * @var string the Type of renderer used
-     */
-    protected $mode;
-    /**
-     * @var \Doku_Renderer the DokuWiki renderer used to create the output
-     */
-    protected $renderer;
-    /**
-     * @var SearchConfig the configured search - gives access to columns etc.
-     */
-    protected $searchConfig;
 
-    /**
-     * @var Column[] the list of columns to be displayed
-     */
-    protected $columns;
-
-    /**
-     * @var  Value[][] the search result
-     */
-    protected $result;
-
-    /**
-     * @var int number of all results
-     */
+    /** @var int number of all results */
     protected $resultColumnCount;
 
-    /**
-     * Initialize the Aggregation renderer and executes the search
-     *
-     * You need to call @param string $id
-     * @param string $mode
-     * @param \Doku_Renderer $renderer
-     * @param SearchConfig $searchConfig
-     * @see render() on the resulting object.
-     *
-     */
+    /** @inheritdoc */
     public function __construct($id, $mode, \Doku_Renderer $renderer, SearchConfig $searchConfig)
     {
-        $this->id = $id;
-        $this->mode = $mode;
-        $this->renderer = $renderer;
-        $this->searchConfig = $searchConfig;
-        $this->data = $searchConfig->getConf();
-        $this->columns = $searchConfig->getColumns();
-
-        $this->result = $this->searchConfig->execute();
+        parent::__construct($id, $mode, $renderer, $searchConfig);
         $this->resultColumnCount = count($this->columns);
-        $this->resultPIDs = $this->searchConfig->getPids();
     }
 
-    /**
-     * Create the list on the renderer
-     */
-    public function render()
+    /** @inheritdoc */
+    public function render($showNotFound = false)
     {
-        $nestedResult = new NestedResult($this->result);
-        $root = $nestedResult->getRoot($this->data['nesting']);
-
         $this->startScope();
-        $this->renderNode($root);
+        if ($this->result) {
+            $nestedResult = new NestedResult($this->result);
+            $root = $nestedResult->getRoot($this->data['nesting']);
+            $this->renderNode($root);
+        } elseif ($showNotFound) {
+            $this->renderer->cdata($this->helper->getLang('none'));
+        }
         $this->finishScope();
     }
 

--- a/meta/AggregationTable.php
+++ b/meta/AggregationTable.php
@@ -7,111 +7,30 @@ namespace dokuwiki\plugin\struct\meta;
  *
  * @package dokuwiki\plugin\struct\meta
  */
-class AggregationTable
+class AggregationTable extends Aggregation
 {
-    /**
-     * @var string the page id of the page this is rendered to
-     */
-    protected $id;
-    /**
-     * @var string the Type of renderer used
-     */
-    protected $mode;
-    /**
-     * @var \Doku_Renderer the DokuWiki renderer used to create the output
-     */
-    protected $renderer;
-    /**
-     * @var SearchConfig the configured search - gives access to columns etc.
-     */
-    protected $searchConfig;
+    /** @var array for summing up columns */
+    protected $sums;
 
-    /**
-     * @var Column[] the list of columns to be displayed
-     */
-    protected $columns;
-
-    /**
-     * @var  Value[][] the search result
-     */
-    protected $result;
-
-    /**
-     * @var int number of all results
-     */
-    protected $resultCount;
-
-    /**
-     * @var string[] the result PIDs for each row
-     */
+    /** @var string[] the result PIDs for each row */
     protected $resultPIDs;
     protected $resultRids;
     protected $resultRevs;
 
-    /**
-     * @var array for summing up columns
-     */
-    protected $sums;
-
-    /**
-     * @var bool skip full table when no results found
-     */
-    protected $simplenone = true;
-
-    /**
-     * @todo we might be able to get rid of this helper and move this to SearchConfig
-     * @var \helper_plugin_struct_config
-     */
-    protected $helper;
-
-    /**
-     * @var array the original configuration data
-     */
-    protected $data;
-
-    /**
-     * Initialize the Aggregation renderer and executes the search
-     *
-     * You need to call @param string $id
-     * @param string $mode
-     * @param \Doku_Renderer $renderer
-     * @param SearchConfig $searchConfig
-     * @see render() on the resulting object.
-     *
-     */
     public function __construct($id, $mode, \Doku_Renderer $renderer, SearchConfig $searchConfig)
     {
-        $this->id = $id;
-        $this->mode = $mode;
-        $this->renderer = $renderer;
-        $this->searchConfig = $searchConfig;
-        $this->data = $searchConfig->getConf();
-        $this->columns = $searchConfig->getColumns();
-
-        $this->result = $this->searchConfig->execute();
-        $this->resultCount = $this->searchConfig->getCount();
+        parent::__construct($id, $mode, $renderer, $searchConfig);
         $this->resultPIDs = $this->searchConfig->getPids();
         $this->resultRids = $this->searchConfig->getRids();
         $this->resultRevs = $this->searchConfig->getRevs();
-        $this->helper = plugin_load('helper', 'struct_config');
     }
 
-    /**
-     * Returns the page id for the table
-     */
-    public function getID()
-    {
-        return $this->id;
-    }
-
-    /**
-     * Create the table on the renderer
-     */
-    public function render()
+    /** @inheritdoc */
+    public function render($showNotFound = false)
     {
 
         // abort early if there are no results at all (not filtered)
-        if (!$this->resultCount && !$this->isDynamicallyFiltered() && $this->simplenone) {
+        if (!$this->resultCount && !$this->isDynamicallyFiltered() && $showNotFound) {
             $this->startScope();
             $this->renderer->cdata($this->helper->getLang('none'));
             $this->finishScope();

--- a/meta/AggregationValue.php
+++ b/meta/AggregationValue.php
@@ -9,83 +9,22 @@ namespace dokuwiki\plugin\struct\meta;
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Iain Hallam <iain@nineworlds.net>
  */
-class AggregationValue
+class AggregationValue extends Aggregation
 {
-    /**
-     * @var string the page id of the page this is rendered to
-     */
-    protected $id;
-    /**
-     * @var string the Type of renderer used
-     */
-    protected $mode;
-    /**
-     * @var Doku_Renderer the DokuWiki renderer used to create the output
-     */
-    protected $renderer;
-    /**
-     * @var SearchConfig the configured search - gives access to columns etc.
-     */
-    protected $searchConfig;
 
     /**
      * @var Column the column to be displayed
      */
     protected $column;
 
-    /**
-     * @var  Value[][] the search result
-     */
-    protected $result;
-
-    /**
-     * @var int number of all results
-     */
-    protected $resultCount;
-
-    /**
-     * @todo we might be able to get rid of this helper and move this to SearchConfig
-     * @var helper_plugin_struct_config
-     */
-    protected $helper;
-
-    /**
-     * Initialize the Aggregation renderer and executes the search
-     *
-     * You need to call @param string $id
-     * @param string $mode
-     * @param Doku_Renderer $renderer
-     * @param SearchConfig $searchConfig
-     * @see render() on the resulting object.
-     *
-     */
+    /** @inheritdoc */
     public function __construct($id, $mode, \Doku_Renderer $renderer, SearchConfig $searchConfig)
     {
-        // Parameters
-        $this->id = $id;
-        $this->mode = $mode;
-        $this->renderer = $renderer;
-        $this->searchConfig = $searchConfig;
-
-        // Search info
-        $this->data = $this->searchConfig->getConf();
-        $columns = $this->searchConfig->getColumns();
-        $this->column = $columns[0];
-
         // limit to first result
-        $this->searchConfig->setLimit(1);
-        $this->searchConfig->setOffset(0);
+        $searchConfig->setLimit(1);
+        $searchConfig->setOffset(0);
 
-        // Run the search
-        $result = $this->searchConfig->execute();
-        $this->resultCount = $this->searchConfig->getCount();
-
-        // Change from two-dimensional array with one entry to one-dimensional array
-        if (sizeof($result) > 0)
-            $this->result = $result[0];
-
-        // Load helper
-        $this->helper = plugin_load('helper', 'struct_config');
+        parent::__construct($id, $mode, $renderer, $searchConfig);
     }
 
     /**
@@ -99,7 +38,7 @@ class AggregationValue
 
         // Check that we actually got a result
         if ($this->resultCount) {
-            $this->renderValue($this->result);
+            $this->renderValue($this->result[0]); // only one result
         } else {
             if ($show_not_found) {
                 $this->renderer->cdata($this->helper->getLang('none'));
@@ -107,8 +46,6 @@ class AggregationValue
         }
 
         $this->finishScope();
-
-        return;
     }
 
     /**
@@ -140,11 +77,10 @@ class AggregationValue
     }
 
     /**
-     * @param $resultrow
+     * @param Value[] $resultrow
      */
     protected function renderValue($resultrow)
     {
-        // @var  Value  $value
         foreach ($resultrow as $column => $value) {
             if ($value->isEmpty()) {
                 continue;

--- a/meta/ConfigParser.php
+++ b/meta/ConfigParser.php
@@ -39,6 +39,7 @@ class ConfigParser
             'schemas' => array(),
             'sort' => array(),
             'csv' => true,
+            'nesting' => 0,
         );
         // parse info
         foreach ($lines as $line) {
@@ -115,6 +116,10 @@ class ConfigParser
                 case 'target':
                 case 'page':
                     $this->config['target'] = cleanID($val);
+                    break;
+                case 'nesting':
+                case 'nest':
+                    $this->config['nesting'] = (int) $val;
                     break;
                 default:
                     $data = array('config' => &$this->config, 'key' => $key, 'val' => $val);

--- a/meta/NestedResult.php
+++ b/meta/NestedResult.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+/**
+ * This class builds a nested tree from a search result
+ *
+ * This is used to create the nested output in the AggregationList
+ */
+class NestedResult
+{
+
+    /** @var NestedValue[] */
+    protected $nodes = [];
+
+    /** @var Value[][] */
+    protected $result;
+
+    /**
+     * @param Value[][] $result the original search result
+     * @return void
+     */
+    public function __construct($result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * Get the nested result
+     *
+     * @param int $nesting the nesting level to use
+     * @return NestedValue the root node of the nested tree
+     */
+    public function getRoot($nesting) {
+        $this->nodes = [];
+        $root = new NestedValue(null, -1);
+
+        if(!$this->result) return $root;
+        foreach ($this->result as $row) {
+            $this->nestBranch($root, $row, $nesting);
+        }
+
+        return $root;
+    }
+
+    /**
+     * Creates nested nodes for a given result row
+     *
+     * Splits up multi Values into separate nodes, when used in nesting
+     *
+     * @param Value[] $row current result row to work on
+     * @param int $nesting number of wanted nesting levels
+     * @param int $depth current nesting depth (used in recursion)
+     */
+    protected function nestBranch(NestedValue $parent, $row, $nesting, $depth = 0)
+    {
+        // nesting level reached, add row and return
+        if($depth >= $nesting) {
+            $parent->addResultRow($row);
+            return;
+        }
+
+        $valObj = array_shift($row);
+        if (!$valObj) return; // no more values to nest, usually shouldn't happen
+
+        if ($valObj->getColumn()->isMulti()) {
+            // split up multi values into separate nodes
+            $values = $valObj->getValue();
+            foreach ($values as $value) {
+                $newValue = new Value($valObj->getColumn(), $value);
+                $node = $this->getNodeForValue($newValue, $depth);
+                $parent->addChild($node);
+                $this->nestBranch($node, $row, $nesting, $depth + 1);
+            }
+        } else {
+            $node = $this->getNodeForValue($valObj, $depth);
+            $parent->addChild($node);
+            $this->nestBranch($node, $row, $nesting, $depth + 1);
+
+        }
+    }
+
+    /**
+     * Create or get existing Node from the tree
+     *
+     * @param Value $value
+     * @param int $depth
+     * @return NestedValue
+     */
+    protected function getNodeForValue(Value $value, $depth)
+    {
+        $node = new NestedValue($value, $depth);
+        $key = (string) $node;
+        if (!isset($this->nodes[$key])) {
+            $this->nodes[$key] = $node;
+        }
+        return $this->nodes[$key];
+    }
+}
+
+

--- a/meta/NestedValue.php
+++ b/meta/NestedValue.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace dokuwiki\plugin\struct\meta;
+
+use dokuwiki\Utf8\Sort;
+
+/**
+ * Object to create a tree of values
+ *
+ * You should not create these yourself, but use the NestedResult class instead
+ */
+class NestedValue
+{
+
+    /** @var Value */
+    protected $value;
+
+    /** @var NestedValue[] */
+    protected $children = [];
+
+    /** @var Value[][] */
+    protected $resultRows = [];
+
+    /** @var int the nesting depth */
+    protected $depth;
+
+    /**
+     * Create a nested version of the given value
+     *
+     * @param Value|null $value The value to store, null for root node
+     * @param int $depth The depth of this node (avoids collision where the same values are selected on multiple levels)
+     */
+    public function __construct(?Value $value, $depth = 0)
+    {
+        $this->value = $value;
+        $this->depth = $depth;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    /**
+     * Access the stored value
+     *
+     * @return Value|null the value stored in this node, null for root node
+     */
+    public function getValueObject()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Add a child node
+     *
+     * Nodes with the same key (__toString()) will be overwritten
+     *
+     * @param NestedValue $child
+     * @return void
+     */
+    public function addChild(NestedValue $child)
+    {
+        $this->children[(string)$child] = $child; // ensures uniqueness
+    }
+
+    /**
+     * Get all child nodes
+     *
+     * @return NestedValue[]
+     */
+    public function getChildren()
+    {
+        $children = $this->children;
+        usort($children, [$this, 'sortChildren']);
+        return $children;
+    }
+
+    /**
+     * Add a result row to this node
+     *
+     * @param Value[] $row
+     * @return void
+     */
+    public function addResultRow($row)
+    {
+        $this->resultRows[] = $row;
+    }
+
+    /**
+     * Get all result rows stored in this node
+     *
+     * @return Value[][]
+     */
+    public function getResultRows()
+    {
+        return $this->resultRows;
+    }
+
+    /**
+     * Get a unique key for this node
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->value === null) return ''; // root node
+        return $this->value->__toString() . '-' . $this->depth;
+    }
+
+    /**
+     * Custom comparator to sort the children of this node
+     *
+     * @param NestedValue $a
+     * @param NestedValue $b
+     * @return int
+     */
+    public function sortChildren(NestedValue $a, NestedValue $b)
+    {
+        // note: the way NestedResults build the NestedValues, the value object should
+        // always contain a single value only. But since the associated column is still
+        // a multi-value column, getCompareValue() will still return an array.
+        // So here we treat all returns as array and join them with a dash (even though
+        // there should never be more than one value in there)
+        return Sort::strcmp(
+            join('-', (array)$a->getValueObject()->getCompareValue()),
+            join('-', (array)$b->getValueObject()->getCompareValue())
+        );
+    }
+
+}

--- a/meta/Value.php
+++ b/meta/Value.php
@@ -222,4 +222,15 @@ class Value
     {
         return '' !== ((string)$input);
     }
+
+    /**
+     * Get a string representation of this value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '[' . $this->getColumn()->getFullQualifiedLabel() . '] ' .
+            join(',', (array)$this->getRawValue());
+    }
 }

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -12,34 +12,13 @@ use dokuwiki\plugin\struct\meta\ConfigParser;
 use dokuwiki\plugin\struct\meta\SearchConfig;
 use dokuwiki\plugin\struct\meta\StructException;
 
-class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
+class syntax_plugin_struct_list extends syntax_plugin_struct_table
 {
-    /** @var string which class to use for output */
+    /** @inheritdoc */
     protected $tableclass = AggregationList::class;
 
-    /**
-     * @return string Syntax mode type
-     */
-    public function getType()
-    {
-        return 'substition';
-    }
-
-    /**
-     * @return string Paragraph type
-     */
-    public function getPType()
-    {
-        return 'block';
-    }
-
-    /**
-     * @return int Sort order - Low numbers go before high numbers
-     */
-    public function getSort()
-    {
-        return 155;
-    }
+    /** @inheritdoc */
+    protected $illegalOptions = ['dynfilters', 'summarize', 'rownumbers', 'widths', 'summary'];
 
     /**
      * Connect lookup pattern to lexer.
@@ -52,48 +31,6 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
     }
 
     /**
-     * Handle matches of the struct syntax
-     *
-     * @param string $match The match of the syntax
-     * @param int $state The state of the handler
-     * @param int $pos The position in the document
-     * @param Doku_Handler $handler The handler
-     * @return array Data for the renderer
-     */
-    public function handle($match, $state, $pos, Doku_Handler $handler)
-    {
-        global $conf;
-
-        $lines = explode("\n", $match);
-        array_shift($lines);
-        array_pop($lines);
-
-        try {
-            $parser = new ConfigParser($lines);
-            $config = $parser->getConfig();
-            return $config;
-        } catch (StructException $e) {
-            msg($e->getMessage(), -1, $e->getLine(), $e->getFile());
-            if ($conf['allowdebug']) msg('<pre>' . hsc($e->getTraceAsString()) . '</pre>', -1);
-            return null;
-        }
-    }
-
-    /**
-     * Checks for options that do not work in a list aggregation
-     *
-     * @param array $config
-     */
-    protected function checkForInvalidOptions($config)
-    {
-        $illegal = ['dynfilters', 'summarize', 'rownumbers', 'widths', 'summary'];
-        foreach ($illegal as $illegalOption)
-        if (!empty($config[$illegalOption])) {
-            throw new StructException('illegal option', $illegalOption);
-        }
-    }
-
-    /**
      * Render xhtml output or metadata
      *
      * @param string $mode Renderer mode (supported modes: xhtml)
@@ -101,7 +38,7 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
      * @param array $data The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, Doku_Renderer $renderer, $data)
+    public function Xrender($mode, Doku_Renderer $renderer, $data)
     {
         if ($mode != 'xhtml') return false;
         if (!$data) return false;
@@ -109,7 +46,6 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
         global $conf;
 
         try {
-            $this->checkForInvalidOptions($data);
             $search = new SearchConfig($data);
 
             /** @var AggregationList $list */
@@ -128,5 +64,3 @@ class syntax_plugin_struct_list extends DokuWiki_Syntax_Plugin
         return true;
     }
 }
-
-// vim:ts=4:sw=4:et:


### PR DESCRIPTION
Currently the list aggregation is more of an after thought than a real useful aggregation. This patch starts to improve on that. It adds a new config `nested` which accepts an integer. This integer defines how many of the selected columns should be used to nest the list.

Example. A normal search result might return:

* audi a80 andi
* audi quattro karsten
* bmw i3 detlef
* bmw i3 jörg

Using a nesting level of 1 would use the first column as grouping:

* audi
  * a80 andi
  * quattro karsten
* bmw
  * i3 detlef
  * i3 jörg

A nesting level of 2 would use the first two columns:

* audi
  * a80
    * andi
  * quattro
    * karsten
* bmw
  * i3
    * detlef
    * jörg

When one of the nesting columns uses multivalues, the values are split into single values and the nested subnodes duplicated under each of their parent multivalues.

Output XHTML has been improved to make styling easier.

Still open:

* allow setting a wrapper class to ease styling
* have a way to nest by first letter (undecided on that)