### PR TITLE
Fix a whitespace issue in aggregation table

### DIFF
--- a/print.less
+++ b/print.less
@@ -20,3 +20,17 @@
 .dokuwiki .struct_entry_form {
   display: none;
 }
+
+.dokuwiki .structaggregation {
+  &.structaggregationtable, &.structaggregationeditortable {
+    table.inline td {
+      & > *:last-child {
+        margin-bottom: 0;
+      }
+      & > *:first-child {
+        margin-top: 0;
+      }
+    }
+  }
+}
+

--- a/style.less
+++ b/style.less
@@ -334,6 +334,13 @@ form.struct_newschema {
 
 .dokuwiki .structaggregation {
 
+    &.structaggregationtable,
+    &.structaggregationeditortable {
+        table.inline td > *:last-child {
+            margin-bottom: 0;
+        }
+    }
+
     &.structaggregationlist > ul li div {
         display: inline;
 
@@ -424,6 +431,7 @@ form.struct_newschema {
         background-position-x: 2px;
     }
 }
+
 
 .dokuwiki .structaggregationcloud {
     ul {

--- a/style.less
+++ b/style.less
@@ -432,7 +432,6 @@ form.struct_newschema {
     }
 }
 
-
 .dokuwiki .structaggregationcloud {
     ul {
         text-align: center;


### PR DESCRIPTION
In a cell with data of type wiki, the non-zero margin-bottom of the last block element (and the non-zero margin-top of the first block element in the print version) creates an unpleasant whitespace.

This fixes #661.