### PR TITLE
Add custom joins

### DIFF
--- a/_test/AccessTableDataReplacementTest.php
+++ b/_test/AccessTableDataReplacementTest.php
@@ -184,7 +184,7 @@ class AccessTableDataReplacementTest extends StructTest
                         AND PAGEEXISTS(data_bar.pid) = 1
                         AND (
                             data_bar.rid != 0
-                            OR (data_bar_ASSIGNED = 1 OR data_bar_ASSIGNED IS NULL)
+                            OR (ASSIGNED = 1 OR ASSIGNED IS NULL)
                         )
                     )
                 )

--- a/_test/AccessTableDataReplacementTest.php
+++ b/_test/AccessTableDataReplacementTest.php
@@ -184,7 +184,7 @@ class AccessTableDataReplacementTest extends StructTest
                         AND PAGEEXISTS(data_bar.pid) = 1
                         AND (
                             data_bar.rid != 0
-                            OR (ASSIGNED = 1 OR ASSIGNED IS NULL)
+                            OR (data_bar_ASSIGNED = 1 OR data_bar_ASSIGNED IS NULL)
                         )
                     )
                 )

--- a/_test/AccessTableDataSQLTest.php
+++ b/_test/AccessTableDataSQLTest.php
@@ -51,12 +51,12 @@ class AccessTableDataSQLTest extends StructTest
                 "SELECT DATA.pid AS PID,
                         DATA.col1 AS out1,
                         DATA.col2 AS out2,
-                        GROUP_CONCAT_DISTINCT(M3.value,'" . Search::CONCAT_SEPARATOR . "') AS out3
+                        GROUP_CONCAT_DISTINCT(M1.value,'" . Search::CONCAT_SEPARATOR . "') AS out3
                    FROM data_testtable AS DATA
-                   LEFT OUTER JOIN multi_testtable AS M3
-                     ON DATA.pid = M3.pid
-                    AND DATA.rev = M3.rev
-                    AND M3.colref = 3
+                   LEFT OUTER JOIN multi_testtable AS M1
+                     ON DATA.pid = M1.pid
+                    AND DATA.rev = M1.rev
+                    AND M1.colref = 3
                   WHERE (DATA.pid = ?
                     AND DATA.rev = ?)
                GROUP BY DATA.pid,out1,out2",

--- a/_test/ConfigParserTest.php
+++ b/_test/ConfigParserTest.php
@@ -17,7 +17,7 @@ class ConfigParserTest extends StructTest
     public function test_simple()
     {
         $lines = [
-            "schema    : testtable, another, foo bar",
+            "schema    : testtable, another ON field = %pageid%, foo bar",
             "cols      : %pageid%, count",
             "sort      : ^count",
             "sort      : %pageid%, ^bam",
@@ -49,16 +49,19 @@ class ConfigParserTest extends StructTest
                         [
                             0 => 'testtable',
                             1 => '',
+                            2 => [],
                         ],
                     1 =>
                         [
                             0 => 'another',
                             1 => '',
+                            2 => ['field', '=', '%pageid%'],
                         ],
                     2 =>
                         [
                             0 => 'foo',
                             1 => 'bar',
+                            2 => [],
                         ],
                 ],
             'cols' =>

--- a/_test/InlineConfigParserTest.php
+++ b/_test/InlineConfigParserTest.php
@@ -17,7 +17,7 @@ class InlineConfigParserTest extends StructTest
     public function test_simple()
     {
         // Same initial setup as ConfigParser.test
-        $inline = '"testtable, another, foo bar"."%pageid%, count" ';
+        $inline = '"testtable, another ON another.a = testtable.b, foo bar ON bar.a = testtable.a"."%pageid%, count" ';
         $inline .= '?sort: ^count sort: "%pageid%, ^bam" align: "r,l,center,foo"';
         // Add InlineConfigParser-specific tests:
         $inline .= ' & "%pageid% != start" | "count = 1"';
@@ -38,9 +38,9 @@ class InlineConfigParserTest extends StructTest
             'limit' => 0,
             'rownumbers' => false,
             'schemas' => [
-                ['testtable', ''],
-                ['another', ''],
-                ['foo', 'bar'],
+                ['testtable', '', []],
+                ['another', '', ['another.a', '=', 'testtable.b']],
+                ['foo', 'bar', ['bar.a', '=', 'testtable.a']],
             ],
             'sepbyheaders' => false,
             'sort' => [

--- a/_test/SearchConfigParameterTest.php
+++ b/_test/SearchConfigParameterTest.php
@@ -77,8 +77,8 @@ class SearchConfigParameterTest extends StructTest
 
         $data = [
             'schemas' => [
-                ['schema1', 'alias1'],
-                ['schema2', 'alias2'],
+                ['schema1', 'alias1', []],
+                ['schema2', 'alias2', []],
             ],
             'cols' => [
                 '%pageid%',
@@ -142,8 +142,8 @@ class SearchConfigParameterTest extends StructTest
     {
         $data = [
             'schemas' => [
-                ['schema1', 'alias1'],
-                ['schema2', 'alias2'],
+                ['schema1', 'alias1', []],
+                ['schema2', 'alias2', []],
             ],
             'cols' => [
                 '%pageid%',
@@ -194,8 +194,8 @@ class SearchConfigParameterTest extends StructTest
     {
         $data = [
             'schemas' => [
-                ['schema1', 'alias1'],
-                ['schema2', 'alias2'],
+                ['schema1', 'alias1', []],
+                ['schema2', 'alias2', []],
             ],
             'cols' => [
                 '%pageid%',
@@ -228,7 +228,7 @@ class SearchConfigParameterTest extends StructTest
 
         $data = [
             'schemas' => [
-                ['schema2', 'alias2'],
+                ['schema2', 'alias2', []],
             ],
             'cols' => [
                 'afirst'

--- a/_test/SearchConfigTest.php
+++ b/_test/SearchConfigTest.php
@@ -49,7 +49,8 @@ class SearchConfigTest extends StructTest
             ]
         );
 
-        $searchConfig = new SearchConfig(['schemas' => [['schema1', 'alias']]]);
+        $searchConfig = new SearchConfig(['schemas' => [['schema1', 'alias', []]]]);
+
         $this->assertEquals('test', $searchConfig->applyFilterVars('$STRUCT.first$'));
         $this->assertEquals('test', $searchConfig->applyFilterVars('$STRUCT.alias.first$'));
         $this->assertEquals('test', $searchConfig->applyFilterVars('$STRUCT.schema1.first$'));
@@ -94,7 +95,7 @@ class SearchConfigTest extends StructTest
             ]
         );
 
-        $searchConfig = new SearchConfig(['schemas' => [['schema3', 'alias']]]);
+        $searchConfig = new SearchConfig(['schemas' => [['schema3', 'alias', []]]]);
         $this->assertEquals('', $searchConfig->applyFilterVars('$STRUCT.afirst$'));
         $this->assertEquals('test', $searchConfig->applyFilterVars('$STRUCT.schema2.afirst$'));
 

--- a/_test/SearchTest.php
+++ b/_test/SearchTest.php
@@ -235,8 +235,8 @@ class SearchTest extends StructTest
         $this->assertEquals(2, count($joincols));
         $this->assertInstanceOf(meta\PageColumn::class, $joincols[0]);
         $this->assertInstanceOf(meta\PageColumn::class, $joincols[1]);
-        $this->assertEquals('schema2', $joincols[0]->getTable());
-        $this->assertEquals('schema1', $joincols[1]->getTable());
+        $this->assertEquals('schema1', $joincols[0]->getTable());
+        $this->assertEquals('schema2', $joincols[1]->getTable());
 
         $search->addColumn('first');
         $this->assertEquals('schema1', $search->columns[0]->getTable());

--- a/_test/action/LookupAjaxTest.php
+++ b/_test/action/LookupAjaxTest.php
@@ -36,10 +36,10 @@ class LookupAjaxTest extends StructTest
     {
         $testLabel = 'testcontent';
         global $INPUT;
-        $INPUT->post->set('schema', 'wikilookup');
+        $INPUT->post->set('schema', 'wikilookup', );
         $INPUT->post->set('entry', ['FirstFieldText' => $testLabel]);
         $INPUT->post->set('searchconf', json_encode([
-            'schemas' => [['wikilookup', '']],
+            'schemas' => [['wikilookup', '', []]],
             'cols' => ['*']
         ]));
         $call = 'plugin_struct_aggregationeditor_save';

--- a/_test/mock/AccessTableDataNoDB.php
+++ b/_test/mock/AccessTableDataNoDB.php
@@ -34,11 +34,15 @@ class AccessTableDataNoDB extends AccessTablePage
         $sort = 0;
         foreach ($singles as $single) {
             $sort += 1;
-            $this->schema->columns[] = new Column($sort, new $single(), $sort);
+            $col = new Column($sort, new $single(), $sort);
+            $col->getType()->setContext($col);
+            $this->schema->columns[] = $col;
         }
         foreach ($multis as $multi) {
             $sort += 1;
-            $this->schema->columns[] = new Column($sort, new $multi(null, null, true), $sort);
+            $col = new Column($sort, new $multi(null, null, true), $sort);
+            $col->getType()->setContext($col);
+            $this->schema->columns[] = $col;
         }
     }
 

--- a/_test/mock/Search.php
+++ b/_test/mock/Search.php
@@ -16,6 +16,8 @@ class Search extends meta\Search
 
     public $dynamicFilter = array();
 
+    public $joins = array();
+
     /**
      * Register a dummy function that always returns false
      */

--- a/_test/types/TextTest.php
+++ b/_test/types/TextTest.php
@@ -125,7 +125,7 @@ class TextTest extends StructTest
                 'NOT LIKE', // comp
                 ['%val1%', '%val2%'], // multiple values
                 '((T.col != \'\' AND (? || T.col || ? NOT LIKE ? OR ? || T.col || ? NOT LIKE ?)))', // expect sql
-                ['before', 'after', '%val1%', 'before', 'after', '%val2%',], // expect opts
+                ['before', 'after', '%val1%', '%val2%',], // expect opts
             ],
         ];
 

--- a/helper/config.php
+++ b/helper/config.php
@@ -60,7 +60,7 @@ class helper_plugin_struct_config extends Plugin
         $comps = implode('|', $comps);
 
         if (!preg_match('/^(.*?)(' . $comps . ')(.*)$/', $val, $match)) {
-            throw new StructException('Invalid search filter %s', hsc($val));
+            throw new StructException('Invalid conditional expression %s', hsc($val));
         }
         array_shift($match); // we don't need the zeroth match
         $match[0] = trim($match[0]);

--- a/helper/config.php
+++ b/helper/config.php
@@ -50,7 +50,7 @@ class helper_plugin_struct_config extends Plugin
      * @return array ($col, $comp, $value)
      * @throws StructException
      */
-    protected function parseFilter($val)
+    public function parseFilter($val)
     {
 
         $comps = Search::$COMPARATORS;

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -505,25 +505,9 @@ abstract class AccessTable
         $QB->addGroupByStatement("DATA.$idColumn");
 
         foreach ($this->schema->getColumns(false) as $col) {
-            $colref = $col->getColref();
-            $colname = 'col' . $colref;
-            $outname = 'out' . $colref;
-
-            if ($col->getType()->isMulti()) {
-                $tn = 'M' . $colref;
-                $QB->addLeftJoin(
-                    'DATA',
-                    $mtable,
-                    $tn,
-                    "DATA.$idColumn = $tn.$idColumn AND DATA.rev = $tn.rev AND $tn.colref = $colref"
-                );
-                $col->getType()->select($QB, $tn, 'value', $outname);
-                $sel = $QB->getSelectStatement($outname);
-                $QB->addSelectStatement("GROUP_CONCAT_DISTINCT($sel, '$sep')", $outname);
-            } else {
-                $col->getType()->select($QB, 'DATA', $colname, $outname);
-                $QB->addGroupByStatement($outname);
-            }
+            $col->getType()->select(
+                $QB, 'DATA', $mtable, 'out' . $col->getColref(), false, $sep
+            );
         }
 
         $pl = $QB->addValue($this->{$idColumn});

--- a/meta/AccessTable.php
+++ b/meta/AccessTable.php
@@ -506,7 +506,12 @@ abstract class AccessTable
 
         foreach ($this->schema->getColumns(false) as $col) {
             $col->getType()->select(
-                $QB, 'DATA', $mtable, 'out' . $col->getColref(), false, $sep
+                $QB,
+                'DATA',
+                $mtable,
+                'out' . $col->getColref(),
+                false,
+                $sep
             );
         }
 

--- a/meta/ConfigParser.php
+++ b/meta/ConfigParser.php
@@ -198,22 +198,13 @@ class ConfigParser
         $parts = explode(',', $val);
         $firsttable = null;
         foreach ($parts as $part) {
-            $words = array_pad(explode(' ', trim($part)), 2, '');
-            [$table, $alias, $on] = $words;
+            $segments = explode('ON', trim($part));
+            [$table, $alias] =  array_pad(explode(' ', trim($segments[0])), 2, '');
             $table = trim($table);
             $alias = trim($alias);
             if (!$table) continue;
-            if (is_null($firsttable)) $firsttable = $alias ? $alias : $table;
-            if ($on == 'ON') {
-                if (count($schemas) == 0) {
-                    throw new StructException('Can not specify JOIN ON for first schema'); 
-                }
-                $condition = $this->helper->parseFilter(
-                    implode(' ', array_slice($words, 3))
-                );
-                if ($condition[1] != '=') {
-                    throw new StructException('Only equality comparison is supported for JOIN conditions'); 
-                }
+            if (count($segments) > 1) {
+                $condition = $this->helper->parseFilter($segments[1]);
             } else {
                 $condition = [];
             }

--- a/meta/QueryBuilder.php
+++ b/meta/QueryBuilder.php
@@ -23,6 +23,8 @@ class QueryBuilder
     /** @var  string[] */
     protected $groupby = [];
 
+    protected $aliasCount = 0;
+
     /**
      * QueryBuilder constructor.
      */
@@ -196,9 +198,8 @@ class QueryBuilder
      */
     public function generateTableAlias($prefix = 'T')
     {
-        static $count = 0;
-        $count++;
-        return $prefix . $count;
+        $this->aliasCount++;
+        return $prefix . $this->aliasCount;
     }
 
     /**

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -581,7 +581,7 @@ class Search
     {
         $sqlBuilder = new SearchSQLBuilder();
         $sqlBuilder->setSelectLatest($this->selectLatest);
-        $sqlBuilder->addSchemas($this->schemas);
+        $sqlBuilder->addSchemas($this->schemas, $this->joins);
         $sqlBuilder->addColumns($this->columns);
         $sqlBuilder->addFilters($this->filter);
         $sqlBuilder->addFilters($this->dynamicFilter);

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -122,7 +122,9 @@ class Search
     }
 
     /**
-     * Returns the columns being matched against for a JOIN ... ON expression.
+     * Returns the columns being matched against for a JOIN ... ON
+     * expression. The result will be ordered such that the first
+     * column is the one from a previously-joined schema.
      * 
      * @param Schema $schema The schema being JOINed to the query
      * @param string $left The LHS of the JOIN ON comparison
@@ -139,10 +141,15 @@ class Search
             throw new StructException('Unrecognoside field ' . $right);
         }
         $table = $schema->getTable();
-        if (($lcol->getTable() != $table) == ($rcol->getTable() != $table)) {
+        $left_is_old_table = $lcol->getTable() != $table;
+        if ($left_is_old_table == ($rcol->getTable() != $table)) {
             throw new StructException("Exactly one side of ON condition $left = $right must be a column of $table" );
         }
-        return array($lcol, $rcol);
+        if ($left_is_old_table) {
+            return array($lcol, $rcol);
+        } else {
+            return array($rcol, $lcol);
+        }
     }
 
     /**

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -678,25 +678,39 @@ class Search
 
         // add "fake" column for special col
         if ($colname == '%pageid%') {
-            return new PageColumn(0, new Page(), $table_or_first);
+            $col = new PageColumn(0, new Page(), $table_or_first);
+            $col->getType()->setContext($col);
+            return $col;
         }
         if ($colname == '%title%') {
-            return new PageColumn(0, new Page(['usetitles' => true]), $table_or_first);
+            $col = new PageColumn(0, new Page(['usetitles' => true]), $table_or_first);
+            $col->getType()->setContext($col);
+            return $col;
         }
         if ($colname == '%lastupdate%') {
-            return new RevisionColumn(0, new DateTime(), $table_or_first);
+            $col = new RevisionColumn(0, new DateTime(), $table_or_first);
+            $col->getType()->setContext($col);
+            return $col;
         }
         if ($colname == '%lasteditor%') {
-            return new UserColumn(0, new User(), $table_or_first);
+            $col = new UserColumn(0, new User(), $table_or_first);
+            $col->getType()->setContext($col);
+            return $col;
         }
         if ($colname == '%lastsummary%') {
-            return new SummaryColumn(0, new AutoSummary(), $table_or_first);
+            $col = new SummaryColumn(0, new AutoSummary(), $table_or_first);
+            $col->getType()->setContext($col);
+            return $col;
         }
         if ($colname == '%rowid%') {
-            return new RowColumn(0, new Decimal(), $table_or_first);
+            $col = new RowColumn(0, new Decimal(), $table_or_first);
+            $col->getType()->setContext($col);
+            return $col;
         }
         if ($colname == '%published%') {
-            return new PublishedColumn(0, new Decimal(), $schema_list[0]);
+            $col = new PublishedColumn(0, new Decimal(), $schema_list[0]);
+            $col->getType()->setContext($col);
+            return $col;
         }
 
         /*

--- a/meta/Search.php
+++ b/meta/Search.php
@@ -115,7 +115,7 @@ class Search
                 );
             }
             if ($joinon[1] != '=') {
-                throw new StructException('Only equality comparison is supported for JOIN conditions'); 
+                throw new StructException('Only equality comparison is supported for JOIN conditions');
             }
             $this->joins[$schema->getTable()] = $this->getJoinColumns($schema, $joinon[0], $joinon[2]);
         }
@@ -125,13 +125,14 @@ class Search
      * Returns the columns being matched against for a JOIN ... ON
      * expression. The result will be ordered such that the first
      * column is the one from a previously-joined schema.
-     * 
+     *
      * @param Schema $schema The schema being JOINed to the query
      * @param string $left The LHS of the JOIN ON comparison
      * @param string $right the RHS of the JOIN ON comparison
      * @return array The first element is the LHS column object and second is the RHS
      */
-    protected function getJoinColumns($schema, $left, $right) {
+    protected function getJoinColumns($schema, $left, $right)
+    {
         $lcol = $this->findColumn($left);
         if ($lcol === false) {
             throw new StructException('Unrecognoside field ' . $left);
@@ -143,7 +144,7 @@ class Search
         $table = $schema->getTable();
         $left_is_old_table = $lcol->getTable() != $table;
         if ($left_is_old_table == ($rcol->getTable() != $table)) {
-            throw new StructException("Exactly one side of ON condition $left = $right must be a column of $table" );
+            throw new StructException("Exactly one side of ON condition $left = $right must be a column of $table");
         }
         if ($left_is_old_table) {
             return array($lcol, $rcol);

--- a/meta/SearchCloud.php
+++ b/meta/SearchCloud.php
@@ -56,10 +56,8 @@ class SearchCloud extends SearchConfig
         $QB->filters()->where('AND', 'tag IS NOT \'\'');
 
         $col = $this->columns[0];
-        $col->getType()->select(
-            $QB, 'data_' . $datatable, 'multi_' . $col->getTable(), 'tag', true
-        );
-        
+        $col->getType()->select($QB, 'data_' . $datatable, 'multi_' . $col->getTable(), 'tag', true);
+
         $QB->addSelectStatement('COUNT(tag)', 'count');
         $QB->addSelectColumn('schema_assignments', 'assigned', 'ASSIGNED');
         if ($col->isMulti()) {

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -44,7 +44,7 @@ class SearchConfig extends Search
 
         // setup schemas and columns
         if (!empty($config['schemas'])) foreach ($config['schemas'] as $schema) {
-            $this->addSchema($schema[0], $schema[1], $scheam[2]);
+            $this->addSchema($schema[0], $schema[1], $schema[2]);
         }
         if (!empty($config['cols'])) foreach ($config['cols'] as $col) {
             $this->addColumn($col);

--- a/meta/SearchConfig.php
+++ b/meta/SearchConfig.php
@@ -44,7 +44,7 @@ class SearchConfig extends Search
 
         // setup schemas and columns
         if (!empty($config['schemas'])) foreach ($config['schemas'] as $schema) {
-            $this->addSchema($schema[0], $schema[1]);
+            $this->addSchema($schema[0], $schema[1], $scheam[2]);
         }
         if (!empty($config['cols'])) foreach ($config['cols'] as $col) {
             $this->addColumn($col);

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -36,8 +36,15 @@ class SearchSQLBuilder
             $datatable = 'data_' . $schema->getTable();
             if ($first_table) {
                 // follow up tables
-                // TODO: Think I'm going to need to create a joinOn method for columns
-                $this->qb->addLeftJoin($first_table, $datatable, $datatable, "$first_table.pid = $datatable.pid");
+                [$lcol, $rcol] = $this->joins[$schema->getTable()];
+                $lefttable = 'data_' . $lcol->getTable();
+                $righttable = 'data_' . $rcol->getTable();
+                $add = new QueryBuilderWhere($QB);
+                $lcol->getType()->joinCondition(
+                    $add, $lefttable, $lcol->getColName(),
+                    $righttable, $rcol->getColName(), $rcol->getType()
+                );
+                $QB->addLeftJoin($lefttable, $righttable, $righttable, $add->toSQL());
             } else {
                 // first table
                 $this->qb->addTable($datatable);

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -46,13 +46,11 @@ class SearchSQLBuilder
                     // Custom join on some other columns
                     $lefttable = 'data_' . $lcol->getTable();
                     $righttable = 'data_' . $rcol->getTable();
-                    $add = new QueryBuilderWhere($QB);
-                    // TODO: Only tricky columns to join over are pages, as they are the only ones that add some OR clauses. For rest, think I can modify filter to handle case of $value being another column.
-                    $lcol->getType()->joinCondition(
-                        $add, $lefttable, $lcol->getColName(),
-                        $righttable, $rcol->getColName(), $rcol->getType()
+                    $on = $lcol->getType()->joinCondition(
+                        $lefttable, $lcol->getColName(), $righttable,
+                        $rcol->getColName(), $rcol->getType()
                     );
-                    $QB->addLeftJoin($lefttable, $righttable, $righttable, $add->toSQL());
+                    $QB->addLeftJoin($lefttable, $righttable, $righttable, $on);
                 }
             } else {
                 // first table

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -36,6 +36,7 @@ class SearchSQLBuilder
             $datatable = 'data_' . $schema->getTable();
             if ($first_table) {
                 // follow up tables
+                // TODO: Think I'm going to need to create a joinOn method for columns
                 $this->qb->addLeftJoin($first_table, $datatable, $datatable, "$first_table.pid = $datatable.pid");
             } else {
                 // first table

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -99,7 +99,7 @@ class SearchSQLBuilder
         $n = 0;
         foreach ($columns as $col) {
             $col->getType()->select(
-                $QB, 'data_' . $col->getTable(), 'multi_' . $col->getTable(),
+                $this->qb, 'data_' . $col->getTable(), 'multi_' . $col->getTable(),
                 'C' . $n++, true, $sep
             );
         }

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -91,29 +91,10 @@ class SearchSQLBuilder
         $sep = Search::CONCAT_SEPARATOR;
         $n = 0;
         foreach ($columns as $col) {
-            $CN = 'C' . $n++;
-
-            if ($col->isMulti()) {
-                $datatable = "data_{$col->getTable()}";
-                $multitable = "multi_{$col->getTable()}";
-                $MN = $this->qb->generateTableAlias('M');
-
-                $this->qb->addLeftJoin(
-                    $datatable,
-                    $multitable,
-                    $MN,
-                    "$datatable.pid = $MN.pid AND $datatable.rid = $MN.rid AND
-                     $datatable.rev = $MN.rev AND
-                     $MN.colref = {$col->getColref()}"
-                );
-
-                $col->getType()->select($this->qb, $MN, 'value', $CN);
-                $sel = $this->qb->getSelectStatement($CN);
-                $this->qb->addSelectStatement("GROUP_CONCAT_DISTINCT($sel, '$sep')", $CN);
-            } else {
-                $col->getType()->select($this->qb, 'data_' . $col->getTable(), $col->getColName(), $CN);
-                $this->qb->addGroupByStatement($CN);
-            }
+            $col->getType()->select(
+                $QB, 'data_' . $col->getTable(), 'multi_' . $col->getTable(),
+                'C' . $n++, true, $sep
+            );
         }
     }
 

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -48,7 +48,7 @@ class SearchSQLBuilder
                     $lefttable = 'data_' . $lcol->getTable();
                     $righttable = 'data_' . $rcol->getTable();
                     $on = $lcol->getType()->joinCondition(
-                        $lefttable, $lcol->getColName(), $righttable,
+                        $this->qb, $lefttable, $lcol->getColName(), $righttable,
                         $rcol->getColName(), $rcol->getType()
                     );
                     $this->qb->addLeftJoin($lefttable, $righttable, $righttable, $on);

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -27,8 +27,9 @@ class SearchSQLBuilder
      * Add the schemas to the query
      *
      * @param Schema[] $schemas Schema names to query
+     * @param array $joins Conditionals to be used when joining tables
      */
-    public function addSchemas($schemas)
+    public function addSchemas($schemas, $joins)
     {
         // basic tables
         $first_table = '';
@@ -38,10 +39,10 @@ class SearchSQLBuilder
             $new_pid = false;
             if ($first_table) {
                 // follow up tables
-                [$lcol, $rcol] = $this->joins[$schema->getTable()];
+                [$lcol, $rcol] = $joins[$schema->getTable()];
                 if ($lcol->getLabel() == '%pageid%' and $rcol->getLabel() == '%pageid%') {
                     // Simple (default) case where we join on page IDs
-                    $QB->addLeftJoin($first_table, $datatable, $datatable, "$first_table.pid = $datatable.pid");
+                    $this->qb->addLeftJoin($first_table, $datatable, $datatable, "$first_table.pid = $datatable.pid");
                 } else {
                     // Custom join on some other columns
                     $lefttable = 'data_' . $lcol->getTable();
@@ -50,7 +51,7 @@ class SearchSQLBuilder
                         $lefttable, $lcol->getColName(), $righttable,
                         $rcol->getColName(), $rcol->getType()
                     );
-                    $QB->addLeftJoin($lefttable, $righttable, $righttable, $on);
+                    $this->qb->addLeftJoin($lefttable, $righttable, $righttable, $on);
                 }
             } else {
                 // first table

--- a/meta/SearchSQLBuilder.php
+++ b/meta/SearchSQLBuilder.php
@@ -48,8 +48,12 @@ class SearchSQLBuilder
                     $lefttable = 'data_' . $lcol->getTable();
                     $righttable = 'data_' . $rcol->getTable();
                     $on = $lcol->getType()->joinCondition(
-                        $this->qb, $lefttable, $lcol->getColName(), $righttable,
-                        $rcol->getColName(), $rcol->getType()
+                        $this->qb,
+                        $lefttable,
+                        $lcol->getColName(),
+                        $righttable,
+                        $rcol->getColName(),
+                        $rcol->getType()
                     );
                     $this->qb->addLeftJoin($lefttable, $righttable, $righttable, $on);
                 }
@@ -100,8 +104,12 @@ class SearchSQLBuilder
         $n = 0;
         foreach ($columns as $col) {
             $col->getType()->select(
-                $this->qb, 'data_' . $col->getTable(), 'multi_' . $col->getTable(),
-                'C' . $n++, true, $sep
+                $this->qb,
+                'data_' . $col->getTable(),
+                'multi_' . $col->getTable(),
+                'C' . $n++,
+                true,
+                $sep
             );
         }
     }

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -488,7 +488,7 @@ abstract class AbstractBaseType
         if ($this->isMulti()) {
             if (!is_null($concat_multi)) {
                 $sel = $QB->getSelectStatement($alias);
-                $QB->addSelectStatement("GROUP_CONCAT($sel, '$concat_sep')", $alias);
+                $QB->addSelectStatement("GROUP_CONCAT_DISTINCT($sel, '$concat_sep')", $alias);
             }
         } else {
             $QB->addGroupByStatement($alias);

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -391,6 +391,43 @@ abstract class AbstractBaseType
     }
 
     /**
+     * Place a condition expression in $add which $left_table and
+     * $right_table can be JOINed ON.  Semantically, this provides an
+     * equality comparison between two columns in the two
+     * schemas. However, in practice it may require more complex
+     * logic, including additional JOINs to pull in other data or
+     * handle multi-valued columns.
+     *
+     * @param QueryBuilderWhere $add The condition ON which to JOIN the tables
+     * @param string $left_table The name of the left table being JOINed
+     * @param string $left_colname The name of the column in the left table being compared against for the JOIN
+     * @param string $right_table The name of the right table being JOINed
+     * @param string $right_colname The name of hte column in the right table being compared against for hte JOIN
+     * @param AbstractBaseType $right_coltype The type of $right_colname
+     */
+    public function joinCondition(QueryBuilderWhere $add, $left_table, $left_colname, $right_table, $right_colname, $right_coltype)
+    {
+        $lhs = $this->joinArgument($add, $left_table, $left_colname);
+        $rhs = $right_coltype->joinArgument($add, $right_table, $right_colname);
+        $add->where('AND', "$lhs = $rhs");
+    }
+
+    /**
+     * Returns an expression for one side of the equality-comparison
+     * used when JOINing schemas in aggregations. It may add
+     * additional conditions to the $add expression or JOIN other
+     * tables, as needed.
+     *
+     * @param QueryBuilderWhere $add The condition ON which to JOIN the tables. May not be used.
+     * @param string $table Name of the table being JOINed
+     * @param string $colname Name of the column being JOINed ON
+     * @return string One side of the equality comparion being used for the JOIN
+     */
+    protected function joinArgument(QueryBuilderWhere $add, $table, $colname) {
+        return "$table.$colname";
+    }
+    
+    /**
      * Add the proper selection for this type to the current Query
      *
      * The default implementation here should be good for nearly all types, it simply

--- a/types/AbstractBaseType.php
+++ b/types/AbstractBaseType.php
@@ -371,7 +371,8 @@ abstract class AbstractBaseType
      * @param bool $test_rid Whether to require RIDs to be equal in the JOIN condition
      * @return string Alias for the multi-table
      */
-    public function joinMulti(QueryBuilder $QB, $datatable, $multitable, $colref, $test_rid = true) {
+    public function joinMulti(QueryBuilder $QB, $datatable, $multitable, $colref, $test_rid = true)
+    {
         $MN = $QB->generateTableAlias('M');
         $condition = "$datatable.pid = $MN.pid ";
         if ($test_rid) $condition .= "AND $datatable.rid = $MN.rid ";
@@ -384,7 +385,7 @@ abstract class AbstractBaseType
         );
         return $MN;
     }
-    
+
     /**
      * This function is used to modify an aggregation query to add a filter
      * for the given column matching the given value. A type should add at
@@ -432,14 +433,14 @@ abstract class AbstractBaseType
      * need to add additional logic to the conditional expression or make
      * additional JOINs.
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string|array The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         return "$tablealias.$colname";
     }
 
@@ -452,7 +453,8 @@ abstract class AbstractBaseType
      * @param string $value The value a column is being compared to
      * @return string A SQL expression processing the value in some way.
      */
-    protected function getSqlConstantValue($value) {
+    protected function getSqlConstantValue($value)
+    {
         return $value;
     }
 
@@ -477,8 +479,11 @@ abstract class AbstractBaseType
         $add = new QueryBuilderWhere($QB);
         $op = 'AND';
         $lhs = $this->getSqlCompareValue($add, $left_table, $left_colname, $op);
-        $rhs = $this->getSqlConstantValue($right_coltype->getSqlCompareValue($add, $right_table, $right_colname, $op));
-        // FIXME: Need to handle possibility of getSqlCompareValue returning multiple values (i.e., due to joining on page name)
+        $rhs = $this->getSqlConstantValue(
+            $right_coltype->getSqlCompareValue($add, $right_table, $right_colname, $op)
+        );
+        // FIXME: Need to handle possibility of getSqlCompareValue returning multiple
+        //        values (i.e., due to joining on page name)
         // FIXME: Need to consider how/whether to handle multi-valued columns
         $AN = $add->getQB()->generateTableAlias('A');
         $subquery = "(SELECT assigned
@@ -506,10 +511,11 @@ abstract class AbstractBaseType
      * @param string $colname Name of the column being JOINed ON
      * @return string One side of the equality comparion being used for the JOIN
      */
-    protected function joinArgument(QueryBuilderWhere $add, $table, $colname) {
+    protected function joinArgument(QueryBuilderWhere $add, $table, $colname)
+    {
         return "$table.$colname";
     }
-    
+
     /**
      * Add the proper selection for this type to the current Query. Handles the
      * possibility of multi-valued columns.
@@ -519,7 +525,7 @@ abstract class AbstractBaseType
      * @param string $multitable The name of the table the values are stored in if the column is multi-valued
      * @param string $alias The added selection *has* to use this column alias
      * @param bool $test_rid Whether to require RIDs to be equal if JOINing multi-table
-     * @param string|null $concat_sep Seperator to concatenate mutli-values together. If null, don't perform concatentation.
+     * @param string|null $concat_sep Seperator to concatenate mutli-values together. Don't concatenate if null.
      */
     public function select(QueryBuilder $QB, $singletable, $multitable, $alias, $test_rid = true, $concat_sep = null)
     {

--- a/types/AutoSummary.php
+++ b/types/AutoSummary.php
@@ -16,7 +16,7 @@ class AutoSummary extends AbstractBaseType
      * @param string $colname
      * @param string $alias
      */
-    public function select(QueryBuilder $QB, $tablealias, $colname, $alias)
+    public function selectCol(QueryBuilder $QB, $tablealias, $colname, $alias)
     {
         $rightalias = $QB->generateTableAlias();
         $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");

--- a/types/AutoSummary.php
+++ b/types/AutoSummary.php
@@ -41,18 +41,18 @@ class AutoSummary extends AbstractBaseType
     /**
      * When using `%lastsummary%`, we need to compare against the `title` table.
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         $QB = $add->getQB();
         $rightalias = $QB->generateTableAlias();
         $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");
 
         return "$rightalias.lastsummary";
-    }    
+    }
 }

--- a/types/AutoSummary.php
+++ b/types/AutoSummary.php
@@ -41,22 +41,18 @@ class AutoSummary extends AbstractBaseType
     /**
      * When using `%lastsummary%`, we need to compare against the `title` table.
      *
-     * @param QueryBuilderWhere $add
-     * @param string $tablealias
-     * @param string $colname
-     * @param string $comp
-     * @param string|\string[] $value
-     * @param string $op
+     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param string $tablealias The table the values are stored in
+     * @param string $colname The column name on the above table
+     * @param string &$op the logical operator this filter shoudl use
+     * @return string The SQL expression to be used on one side of the comparison operator
      */
-    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
-    {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
+                                          $colname, &$op) {
         $QB = $add->getQB();
         $rightalias = $QB->generateTableAlias();
         $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");
 
-        // compare against page and title
-        $sub = $add->where($op);
-        $pl = $QB->addValue($value);
-        $sub->whereOr("$rightalias.lastsummary $comp $pl");
-    }
+        return "$rightalias.lastsummary";
+    }    
 }

--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -116,16 +116,19 @@ class DateTime extends Date
         $QB->addSelectStatement($col, $alias);
     }
 
+
     /**
-     * @param QueryBuilderWhere $add
-     * @param string $tablealias
-     * @param string $colname
-     * @param string $comp
-     * @param string|\string[] $value
-     * @param string $op
+     * Handle case of a revision column, where you need to convert from a Unix 
+     * timestamp.
+     *
+     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param string $tablealias The table the values are stored in
+     * @param string $colname The column name on the above table
+     * @return string The SQL expression to be used on one side of the comparison operator
+     * @param string &$op the logical operator this filter shoudl use
      */
-    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
-    {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
+                                          $colname, &$op) {
         $col = "$tablealias.$colname";
         $QB = $add->getQB();
 
@@ -136,17 +139,9 @@ class DateTime extends Date
             $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");
         }
 
-        /** @var QueryBuilderWhere $add Where additional queries are added to */
-        if (is_array($value)) {
-            $add = $add->where($op); // sub where group
-            $op = 'OR';
-        }
-        foreach ((array)$value as $item) {
-            $pl = $QB->addValue($item);
-            $add->where($op, "$col $comp $pl");
-        }
+        return $col;
     }
-
+ 
     /**
      * When sorting `%lastupdated%`, then sort the data from the `titles` table instead the `data_` table.
      *

--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -102,7 +102,7 @@ class DateTime extends Date
      * @param string $colname
      * @param string $alias
      */
-    public function select(QueryBuilder $QB, $tablealias, $colname, $alias)
+    public function selectCol(QueryBuilder $QB, $tablealias, $colname, $alias)
     {
         $col = "$tablealias.$colname";
 

--- a/types/DateTime.php
+++ b/types/DateTime.php
@@ -118,17 +118,18 @@ class DateTime extends Date
 
 
     /**
-     * Handle case of a revision column, where you need to convert from a Unix 
+     * Handle case of a revision column, where you need to convert from a Unix
      * timestamp.
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
      * @return string The SQL expression to be used on one side of the comparison operator
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
+     * @return string|array The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         $col = "$tablealias.$colname";
         $QB = $add->getQB();
 
@@ -141,7 +142,7 @@ class DateTime extends Date
 
         return $col;
     }
- 
+
     /**
      * When sorting `%lastupdated%`, then sort the data from the `titles` table instead the `data_` table.
      *

--- a/types/Decimal.php
+++ b/types/Decimal.php
@@ -155,30 +155,27 @@ class Decimal extends AbstractMultiBaseType
     /**
      * Decimals need to be casted to proper type for comparison
      *
-     * @param QueryBuilderWhere $add
-     * @param string $tablealias
-     * @param string $colname
-     * @param string $comp
-     * @param string|\string[] $value
-     * @param string $op
+     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param string $tablealias The table the values are stored in
+     * @param string $colname The column name on the above table
+     * @param string &$op the logical operator this filter shoudl use
+     * @return string The SQL expression to be used on one side of the comparison operator
      */
-    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
     {
         $add = $add->where($op); // open a subgroup
         $add->where('AND', "$tablealias.$colname != ''");
          // make sure the field isn't empty
         $op = 'AND';
+        return "CAST($tablealias.$colname AS DECIMAL)";
+    }
 
-        /** @var QueryBuilderWhere $add Where additionional queries are added to */
-        if (is_array($value)) {
-            $add = $add->where($op); // sub where group
-            $op = 'OR';
-        }
-
-        foreach ((array)$value as $item) {
-            $pl = $add->getQB()->addValue($item);
-            $add->where($op, "CAST($tablealias.$colname AS DECIMAL) $comp CAST($pl AS DECIMAL)");
-        }
+    /**
+     * @param string $value The value a column is being compared to
+     * @return string SQL expression casting $value to a decimal
+     */
+    protected function getSqlConstantValue($value) {
+        return "CAST($value AS DECIMAL)";
     }
 
     /**

--- a/types/Decimal.php
+++ b/types/Decimal.php
@@ -155,10 +155,10 @@ class Decimal extends AbstractMultiBaseType
     /**
      * Decimals need to be casted to proper type for comparison
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional  this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string The SQL expression to be used on one side of the comparison operator
      */
     protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
@@ -174,7 +174,8 @@ class Decimal extends AbstractMultiBaseType
      * @param string $value The value a column is being compared to
      * @return string SQL expression casting $value to a decimal
      */
-    protected function getSqlConstantValue($value) {
+    protected function getSqlConstantValue($value)
+    {
         return "CAST($value AS DECIMAL)";
     }
 

--- a/types/Lookup.php
+++ b/types/Lookup.php
@@ -256,14 +256,14 @@ class Lookup extends Dropdown
     /**
      * Compare against lookup table
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string|array The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         $schema = 'data_' . $this->config['schema'];
         $column = $this->getLookupColumn();
         if (!$column) {
@@ -290,7 +290,8 @@ class Lookup extends Dropdown
      * @param string $value The value a column is being compared to
      * @return string A SQL expression processing the value in some way.
      */
-    protected function getSqlConstantValue($value) {
+    protected function getSqlConstantValue($value)
+    {
         $schema = 'data_' . $this->config['schema'];
         $column = $this->getLookupColumn();
         if (!$column) {

--- a/types/Lookup.php
+++ b/types/Lookup.php
@@ -230,12 +230,12 @@ class Lookup extends Dropdown
      * @param string $colname
      * @param string $alias
      */
-    public function select(QueryBuilder $QB, $tablealias, $colname, $alias)
+    public function selectCol(QueryBuilder $QB, $tablealias, $colname, $alias)
     {
         $schema = 'data_' . $this->config['schema'];
         $column = $this->getLookupColumn();
         if (!$column) {
-            parent::select($QB, $tablealias, $colname, $alias);
+            parent::selectCol($QB, $tablealias, $colname, $alias);
             return;
         }
 
@@ -248,7 +248,7 @@ class Lookup extends Dropdown
             "$tablealias.$colname = STRUCT_JSON($rightalias.pid, CAST($rightalias.rid AS DECIMAL)) " .
             "AND $rightalias.latest = 1"
         );
-        $column->getType()->select($QB, $rightalias, $field, $alias);
+        $column->getType()->selectCol($QB, $rightalias, $field, $alias);
         $sql = $QB->getSelectStatement($alias);
         $QB->addSelectStatement("STRUCT_JSON($tablealias.$colname, $sql)", $alias);
     }

--- a/types/Page.php
+++ b/types/Page.php
@@ -187,14 +187,13 @@ class Page extends AbstractMultiBaseType
     /**
      * When using titles, we need to compare against the title table, too.
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return array The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op)
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
     {
         if (!$this->config['usetitles']) {
             return parent::getSqlCompareValue($add, $tablealias, $colname, $op);
@@ -272,6 +271,6 @@ class Page extends AbstractMultiBaseType
     //     if (!$this->config['usetitles']) {
     //         return parent::joinArgument($add, $table, $colname);
     //     }
-    //     // FIXME: How to handle multiple values 
+    //     // FIXME: How to handle multiple values
     // }
 }

--- a/types/Page.php
+++ b/types/Page.php
@@ -121,10 +121,10 @@ class Page extends AbstractMultiBaseType
      * @param string $colname
      * @param string $alias
      */
-    public function select(QueryBuilder $QB, $tablealias, $colname, $alias)
+    public function selectCol(QueryBuilder $QB, $tablealias, $colname, $alias)
     {
         if (!$this->config['usetitles']) {
-            parent::select($QB, $tablealias, $colname, $alias);
+            parent::selectCol($QB, $tablealias, $colname, $alias);
             return;
         }
         $rightalias = $QB->generateTableAlias();

--- a/types/Tag.php
+++ b/types/Tag.php
@@ -115,23 +115,24 @@ class Tag extends AbstractMultiBaseType
     /**
      * Normalize tags before comparing
      *
-     * @param QueryBuilder $QB
-     * @param string $tablealias
-     * @param string $colname
-     * @param string $comp
-     * @param string|string[] $value
-     * @param string $op
+     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param string $tablealias The table the values are stored in
+     * @param string $colname The column name on the above table
+     * @param string &$op the logical operator this filter shoudl use
+     * @return string The SQL expression to be used on one side of the comparison operator
      */
-    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
-    {
-        /** @var QueryBuilderWhere $add Where additionional queries are added to */
-        if (is_array($value)) {
-            $add = $add->where($op); // sub where group
-            $op = 'OR';
-        }
-        foreach ((array)$value as $item) {
-            $pl = $add->getQB()->addValue($item);
-            $add->where($op, "LOWER(REPLACE($tablealias.$colname, ' ', '')) $comp LOWER(REPLACE($pl, ' ', ''))");
-        }
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
+                                          $colname, &$op) {
+        return "LOWER(REPLACE($tablealias.$colname, ' ', ''))";
+    }
+
+    /**
+     * Normalize before comparing.
+     *
+     * @param string $value The value a column is being compared to
+     * @return string A SQL expression processing the value in some way.
+     */
+    protected function getSqlConstantValue($value) {
+        return "LOWER(REPLACE($value, ' ', ''))";
     }
 }

--- a/types/Tag.php
+++ b/types/Tag.php
@@ -115,14 +115,14 @@ class Tag extends AbstractMultiBaseType
     /**
      * Normalize tags before comparing
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         return "LOWER(REPLACE($tablealias.$colname, ' ', ''))";
     }
 
@@ -132,7 +132,8 @@ class Tag extends AbstractMultiBaseType
      * @param string $value The value a column is being compared to
      * @return string A SQL expression processing the value in some way.
      */
-    protected function getSqlConstantValue($value) {
+    protected function getSqlConstantValue($value)
+    {
         return "LOWER(REPLACE($value, ' ', ''))";
     }
 }

--- a/types/TraitFilterPrefix.php
+++ b/types/TraitFilterPrefix.php
@@ -17,40 +17,29 @@ trait TraitFilterPrefix
     /**
      * Comparisons are done against the full string (including prefix/postfix)
      *
-     * @param QueryBuilderWhere $add
-     * @param string $tablealias
-     * @param string $colname
-     * @param string $comp
-     * @param string|string[] $value
-     * @param string $op
+     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param string $tablealias The table the values are stored in
+     * @param string $colname The column name on the above table
+     * @param string &$op the logical operator this filter shoudl use
+     * @return string|array The SQL expression to be used on one side of the comparison operator
      */
-    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
-    {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
+                                          $colname, &$op) {
+        $column = parent::getSqlCompareValue($add, $tablealias, $colname, $op);
+
         $add = $add->where($op); // open a subgroup
-        $add->where('AND', "$tablealias.$colname != ''");
-         // make sure the field isn't empty
+        $add->where('AND', "$column != ''"); // make sure the field isn't empty
         $op = 'AND';
 
-        /** @var QueryBuilderWhere $add Where additionional queries are added to */
-        if (is_array($value)) {
-            $add = $add->where($op); // sub where group
-            $op = 'OR';
-        }
         $QB = $add->getQB();
-        foreach ((array)$value as $item) {
-            $column = "$tablealias.$colname";
-
-            if ($this->config['prefix']) {
-                $pl = $QB->addValue($this->config['prefix']);
-                $column = "$pl || $column";
-            }
-            if ($this->config['postfix']) {
-                $pl = $QB->addValue($this->config['postfix']);
-                $column = "$column || $pl";
-            }
-
-            $pl = $QB->addValue($item);
-            $add->where($op, "$column $comp $pl");
+        if ($this->config['prefix']) {
+            $pl = $QB->addValue($this->config['prefix']);
+            $column = "$pl || $column";
         }
+        if ($this->config['postfix']) {
+            $pl = $QB->addValue($this->config['postfix']);
+            $column = "$column || $pl";
+        }
+        return $column;
     }
 }

--- a/types/TraitFilterPrefix.php
+++ b/types/TraitFilterPrefix.php
@@ -17,14 +17,14 @@ trait TraitFilterPrefix
     /**
      * Comparisons are done against the full string (including prefix/postfix)
      *
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string|array The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         $column = parent::getSqlCompareValue($add, $tablealias, $colname, $op);
 
         $add = $add->where($op); // open a subgroup

--- a/types/User.php
+++ b/types/User.php
@@ -139,14 +139,14 @@ class User extends AbstractMultiBaseType
     }
 
     /**
-     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param QueryBuilderWhere &$add The WHERE or ON clause to contain the conditional this comparator will be used in
      * @param string $tablealias The table the values are stored in
      * @param string $colname The column name on the above table
-     * @param string &$op the logical operator this filter shoudl use
+     * @param string &$op the logical operator this filter should use
      * @return string The SQL expression to be used on one side of the comparison operator
      */
-    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
-                                          $colname, &$op) {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias, $colname, &$op)
+    {
         if (is_a($this->context, 'dokuwiki\plugin\struct\meta\UserColumn')) {
             $QB = $add->getQB();
             $rightalias = $QB->generateTableAlias();
@@ -156,5 +156,4 @@ class User extends AbstractMultiBaseType
 
         return parent::getSqlCompareValue($add, $tablealias, $colname, $comp, $value, $op);
     }
-
 }

--- a/types/User.php
+++ b/types/User.php
@@ -106,7 +106,7 @@ class User extends AbstractMultiBaseType
      * @param string $colname
      * @param string $alias
      */
-    public function select(QueryBuilder $QB, $tablealias, $colname, $alias)
+    public function selectCol(QueryBuilder $QB, $tablealias, $colname, $alias)
     {
         if (is_a($this->context, 'dokuwiki\plugin\struct\meta\UserColumn')) {
             $rightalias = $QB->generateTableAlias();
@@ -115,7 +115,7 @@ class User extends AbstractMultiBaseType
             return;
         }
 
-        parent::select($QB, $tablealias, $colname, $alias);
+        parent::selectCol($QB, $tablealias, $colname, $alias);
     }
 
     /**

--- a/types/User.php
+++ b/types/User.php
@@ -139,29 +139,22 @@ class User extends AbstractMultiBaseType
     }
 
     /**
-     * When using `%lasteditor%`, we need to compare against the `title` table.
-     *
-     * @param QueryBuilderWhere $add
-     * @param string $tablealias
-     * @param string $colname
-     * @param string $comp
-     * @param string|string[] $value
-     * @param string $op
+     * @param QueryBuilderWhere &$add The WHERE or ON clause which will contain the conditional expression this comparator will be used in
+     * @param string $tablealias The table the values are stored in
+     * @param string $colname The column name on the above table
+     * @param string &$op the logical operator this filter shoudl use
+     * @return string The SQL expression to be used on one side of the comparison operator
      */
-    public function filter(QueryBuilderWhere $add, $tablealias, $colname, $comp, $value, $op)
-    {
+    protected function getSqlCompareValue(QueryBuilderWhere &$add, $tablealias,
+                                          $colname, &$op) {
         if (is_a($this->context, 'dokuwiki\plugin\struct\meta\UserColumn')) {
             $QB = $add->getQB();
             $rightalias = $QB->generateTableAlias();
             $QB->addLeftJoin($tablealias, 'titles', $rightalias, "$tablealias.pid = $rightalias.pid");
-
-            // compare against page and title
-            $sub = $add->where($op);
-            $pl = $QB->addValue($value);
-            $sub->whereOr("$rightalias.lasteditor $comp $pl");
-            return;
+            return "$rightalias.lasteditor";
         }
 
-        parent::filter($add, $tablealias, $colname, $comp, $value, $op);
+        return parent::getSqlCompareValue($add, $tablealias, $colname, $comp, $value, $op);
     }
+
 }


### PR DESCRIPTION
This introduces the ability to JOIN schemas in aggregations ON fields other than the page ID. It required some significant refactoring of the SQL generation so will likely need extensive review. 

**Currently this PR is a draft. I have begun writing it so I can keep track of all the changes I have made.**

Fixes #269, #285, #598

This has involved the following changes:

- Introducing additional config syntax to specify what fields to join schemas on (plus associated code to process and store this data)
- Setting the "context" for all of the fake columns used by `Search`.
- Moving logic for handling multi-valued fields to within the `select()` method
- Moving datatype-specific select logic out of `select()` and into `selectCol()` (which gets called from `select()`)
- Adding a `getSqlCompareValue()` method to the datatype classes. This returns an expression for the contents of the column to be used either in filtering or joining. If need be, it will also insert any other conditional expressions needed into a query's WHERE clause. 
- Adding a `getSqlConstantValue()` method to the datatype classes. This will wrap a value that is being compared against in any additional logic that is needed (e.g., making it lower-case or converting it to digits).
- Implement  `filter()` only on `AbstractBaseType` and refactor it to use `getSqlCompareValue()` for the type-specific logic.
- Introducing a `joinCondition()` method to construct alternative JOIN ON clauses when generating SQL queries.
- Adding logic to a number of existing methods to handle custom join conditions.
- Updates to existing tests plus writing new tests for the new features.

Tasks still to do:
- [ ] Decide how to handle comparisons with page IDs and/or names in custom joins
- [ ] Decide how (if at all) to handle joins on columns that are multi-valued
- [ ] Write some additional tests to