### PR TITLE
Fix issue with autocompletion of numeric usernames

### DIFF
--- a/_test/types/UserTest.php
+++ b/_test/types/UserTest.php
@@ -84,5 +84,31 @@ class UserTest extends StructTest
 
         $INPUT->set('search', 'test');
         $this->assertEquals([], $user->handleAjax());
+
+        // Check that numeric usernames are handled properly; PHP's
+        // strange handling of array keys that look like integers has
+        // caused bugs with this in the past.
+        global $auth;
+        $auth->createUser('12345', 'secret_password', 'Some Person', 'someone@example.com');
+        $auth->createUser('54321', 'another_password', 'Someone Else', 's.else@example.com');
+        
+        $user = new User(
+            [
+                'autocomplete' => [
+                    'fullname' => true,
+                    'mininput' => 2,
+                    'maxresult' => 5,
+                ],
+            ]
+        );
+        
+        $INPUT->set('search', 'Some');
+        $this->assertEquals(
+            [
+                ['label' => 'Some Person [12345]', 'value' => '12345'],
+                ['label' => 'Someone Else [54321]', 'value' => '54321']
+            ],
+            $user->handleAjax()
+        );
     }
 }


### PR DESCRIPTION
Fixes #689, where autocomplete can't handle numerical usernames. This PR applies a workaround to some of PHP's strange integer/string-handling behaviour. It also includes an addition to the test for ajax/autocompletion for the username type to check that this fixes the problem (the test was confirmed to fail before the fix was implemented).