### PR TITLE
Change the visibility of functions in the data types

### DIFF
--- a/types/Checkbox.php
+++ b/types/Checkbox.php
@@ -11,7 +11,7 @@ class Checkbox extends AbstractBaseType
      *
      * @return array
      */
-    protected function getOptions()
+    public function getOptions()
     {
         $options = explode(',', $this->config['values']);
         $options = array_map('trim', $options);

--- a/types/Dropdown.php
+++ b/types/Dropdown.php
@@ -14,7 +14,7 @@ class Dropdown extends AbstractBaseType
      *
      * @return array
      */
-    protected function getOptions()
+    public function getOptions()
     {
         $options = explode(',', $this->config['values']);
         $options = array_map('trim', $options);

--- a/types/Lookup.php
+++ b/types/Lookup.php
@@ -44,7 +44,7 @@ class Lookup extends Dropdown
      *
      * @return Column|false
      */
-    protected function getLookupColumn()
+    public function getLookupColumn()
     {
         if ($this->column instanceof Column) return $this->column;
         $this->column = $this->getColumn($this->config['schema'], $this->config['field']);
@@ -58,7 +58,7 @@ class Lookup extends Dropdown
      * @param string $infield
      * @return Column|false
      */
-    protected function getColumn($table, $infield)
+    public function getColumn($table, $infield)
     {
         global $conf;
 
@@ -116,7 +116,7 @@ class Lookup extends Dropdown
      *
      * @return array
      */
-    protected function getOptions()
+    public function getOptions()
     {
         $schema = $this->config['schema'];
         $column = $this->getLookupColumn();


### PR DESCRIPTION
If one wants to use the data types inside other scripts, making some functions public is required.