### PR TITLE
Try to fix placeholder application for bureaucracy fields

### DIFF
--- a/helper/field.php
+++ b/helper/field.php
@@ -47,15 +47,25 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field
      */
     protected function setVal($value)
     {
+        global $INPUT;
+
         if (!$this->column) {
             $value = '';
         } else {
-            $value = $this->replace($value);
-            $validator = new ValueValidator();
-            $this->error = !$validator->validateValue($this->column, $value);
-            if ($this->error) {
-                foreach ($validator->getErrors() as $error) {
-                    msg(hsc($error), -1);
+
+            // This method is called at parsing time, and again on action submit
+            // we really only want to validate the value on action submit
+            //
+            // At parsing time, the value might still be a placeholder. Ideally
+            // bureaucracy would already handle this. But well...
+            if($INPUT->post->has('bureaucracy')) {
+                $validator = new ValueValidator();
+
+                $this->error = !$validator->validateValue($this->column, $value);
+                if ($this->error) {
+                    foreach ($validator->getErrors() as $error) {
+                        msg(hsc($error), -1);
+                    }
                 }
             }
         }
@@ -154,22 +164,23 @@ class helper_plugin_struct_field extends helper_plugin_bureaucracy_field
      * Returns a Value object for the current column.
      * Special handling for Page and Lookup literal form values.
      *
+     * Used for rendering the field only.
+     *
      * @return Value
      */
     protected function createValue()
     {
-        /*
+        // The value in bureaucracy is always a string, if unset init it.
         $preparedValue = $this->opt['value'] ?? '';
-        if($this->column->isMulti()) {
-            // multi-value fields are treated as comma-separated lists
-            $preparedValue = explode(',', $preparedValue);
-            $preparedValue = array_map('trim', $preparedValue);
-            $preparedValue = array_filter($preparedValue);
-        }
-        */
 
-        // input value or appropriately initialized empty value
-        $preparedValue = $this->opt['value'] ?? ($this->column->isMulti() ? [] : '');
+        // apply placeholder replacements
+        $preparedValue = $this->replace($preparedValue);
+
+        // Validating here is actually not a validation, that will happen again in setVal() when
+        // the form is submitted. instead, here we're using it's data cleanup functionality on the value.
+        $validator = new ValueValidator();
+        $validator->validateValue($this->column, $preparedValue);
+        /** @var string|array $preparedValue is now an array or a string */
 
         // page fields might need to be JSON encoded depending on usetitles config
         if (


### PR DESCRIPTION
We were applying replacements in setVal() but that is weirdly called during parsing and then gets cached. But it's also called again when the validation fails... It's all a mess.

This tries to work around the issue, but I am far from sure this hits all the (edge) cases.

Really without a refactoring of bureaucracy it's nearly impossible to interface cleanly with it.

This applies on top of the multival branch fixes.